### PR TITLE
Remove factor of 2 in calculation of likelihood contribution for Gaus…

### DIFF
--- a/AmpTools/MinuitInterface/GaussianBound.cc
+++ b/AmpTools/MinuitInterface/GaussianBound.cc
@@ -50,6 +50,6 @@ double
 GaussianBound::operator()() {
   
   return ( ( m_par->value() - m_centralValue ) * ( m_par->value() - m_centralValue ) ) /
-  ( 2 * m_error * m_error );
+  ( m_error * m_error );
           
 }


### PR DESCRIPTION
…sian bound.  It seems the operator() was returning - ln L and it should return -2 ln L.  This is likely to have affected anyone who used the "gaussian" technique for constraining parameters in a fit.