### PR TITLE
Fixes to the Histogram class in order to properly compute the error

### DIFF
--- a/AmpTools/IUAmpTools/Histogram.cc
+++ b/AmpTools/IUAmpTools/Histogram.cc
@@ -48,6 +48,7 @@ m_xLow( 0 ),
 m_xHigh( 0 ),
 m_entries( 0 ),
 m_binContents( 0 ),
+m_squareOfWeights( 0 ),
 m_name( name ),
 m_title( title ){}
 
@@ -56,9 +57,10 @@ void
 Histogram::clear( void ){
   
   m_binContents = vector< double >( m_nBins );
-  m_sumWeightSq = vector< double >( m_nBins );
+  m_squareOfWeights = vector< double >( m_nBins );
   m_entries = 0;
 }
+
 
 void
 Histogram::normalize( double integral ){
@@ -66,9 +68,8 @@ Histogram::normalize( double integral ){
   double scaleFactor = integral / m_entries;
   
   for( int i = 0; i < m_nBins; ++i ){
-    
     m_binContents[i] *= scaleFactor;
-    m_sumWeightSq[i] *= scaleFactor*scaleFactor;
+    m_squareOfWeights[i] *= (scaleFactor*scaleFactor);
   }
   
   m_entries *= scaleFactor;
@@ -76,14 +77,14 @@ Histogram::normalize( double integral ){
 
 void
 Histogram::operator+=( HistStruct& hStruct ){
-  
-  assert( m_nBins <= MAXBINS );
-  
-  for( int i = 0; i < m_nBins; ++i ){
-    
-    m_binContents[i] += hStruct.contents[i];
-    m_sumWeightSq[i] += hStruct.sumW2[i];
-  }
-  
-  m_entries += hStruct.entries;
+	
+	assert( m_nBins <= MAXBINS );
+	
+	for( int i = 0; i < m_nBins; ++i ){
+		
+		m_binContents[i] += hStruct.contents[i];
+		m_squareOfWeights[i] += hStruct.sumw2[i];
+	}
+	
+	m_entries += hStruct.entries;
 }

--- a/AmpTools/IUAmpTools/Histogram.h
+++ b/AmpTools/IUAmpTools/Histogram.h
@@ -50,8 +50,8 @@ struct HistStruct {
 	float xLow,xHigh;
 	float yLow,yHigh;
 	float entries;
-	float contents[MAXBINS];
-  float sumW2[MAXBINS];
+	float contents[MAXBINS]; //this is the sum of weights
+	float sumw2[MAXBINS];   //this is the sum of weights squared
 };
 
 
@@ -66,6 +66,7 @@ public:
 	/*Pure virtual methods*/
 	virtual void fill( vector< double > value, double weight = 1.0 )= 0;
 	
+
 	virtual TH1* toRoot() const=0;
 	virtual HistStruct toStruct() const=0;
 	virtual Histogram* Clone() const=0;
@@ -87,8 +88,8 @@ protected:
   double m_xHigh;
   
   double m_entries;
-  vector< double > m_binContents;  // this is the sum of the weights
-  vector< double > m_sumWeightSq;
+  vector< double > m_binContents;
+  vector< double > m_squareOfWeights;
   double m_binSizeX;
 	
   int m_dimensions;

--- a/AmpTools/IUAmpTools/Histogram1D.cc
+++ b/AmpTools/IUAmpTools/Histogram1D.cc
@@ -1,17 +1,17 @@
 //******************************************************************************
 // This file is part of AmpTools, a package for performing Amplitude Analysis
-//
+// 
 // Copyright Trustees of Indiana University 2010, all rights reserved
-//
-// This software written by Matthew Shepherd, Ryan Mitchell, and
+// 
+// This software written by Matthew Shepherd, Ryan Mitchell, and 
 //                  Hrayr Matevosyan at Indiana University, Bloomington
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
 // are met:
 // 1. Redistributions of source code must retain the above copyright
 //    notice and author attribution, this list of conditions and the
-//    following disclaimer.
+//    following disclaimer. 
 // 2. Redistributions in binary form must reproduce the above copyright
 //    notice and author attribution, this list of conditions and the
 //    following disclaimer in the documentation and/or other materials
@@ -19,18 +19,18 @@
 // 3. Neither the name of the University nor the names of its contributors
 //    may be used to endorse or promote products derived from this software
 //    without specific prior written permission.
-//
+// 
 // Creation of derivative forms of this software for commercial
 // utilization may be subject to restriction; written permission may be
 // obtained from the Trustees of Indiana University.
-//
-// INDIANA UNIVERSITY AND THE AUTHORS MAKE NO REPRESENTATIONS OR WARRANTIES,
-// EXPRESS OR IMPLIED.  By way of example, but not limitation, INDIANA
-// UNIVERSITY MAKES NO REPRESENTATIONS OR WARRANTIES OF MERCANTABILITY OR
-// FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THIS SOFTWARE OR
-// DOCUMENTATION WILL NOT INFRINGE ANY PATENTS, COPYRIGHTS, TRADEMARKS,
-// OR OTHER RIGHTS.  Neither Indiana University nor the authors shall be
-// held liable for any liability with respect to any claim by the user or
+// 
+// INDIANA UNIVERSITY AND THE AUTHORS MAKE NO REPRESENTATIONS OR WARRANTIES, 
+// EXPRESS OR IMPLIED.  By way of example, but not limitation, INDIANA 
+// UNIVERSITY MAKES NO REPRESENTATIONS OR WARRANTIES OF MERCANTABILITY OR 
+// FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THIS SOFTWARE OR 
+// DOCUMENTATION WILL NOT INFRINGE ANY PATENTS, COPYRIGHTS, TRADEMARKS, 
+// OR OTHER RIGHTS.  Neither Indiana University nor the authors shall be 
+// held liable for any liability with respect to any claim by the user or 
 // any other party arising from use of the program.
 //******************************************************************************
 
@@ -43,107 +43,104 @@
 
 using namespace std;
 
-Histogram1D::Histogram1D() : Histogram()
-{
-  m_dimensions=1;
+Histogram1D::Histogram1D() :
+		Histogram() {
+	m_dimensions = 1;
 }
 
-Histogram1D::Histogram1D( HistStruct& hist ) :
-Histogram()
-{
-  m_binContents.resize(hist.nBins);
-  m_sumWeightSq.resize(hist.nBins);
-  m_entries = hist.entries;
-  m_dimensions = 1;
-  m_nBinsX = hist.nBins;
-  m_nBins = hist.nBins;
-  m_xLow = hist.xLow;
-  m_xHigh = hist.xHigh;
-  
-  for( int i = 0; i < m_nBins; ++i ){
-    
-    m_binContents[i] = hist.contents[i];
-    m_sumWeightSq[i] = hist.sumW2[i];
-  }
+Histogram1D::Histogram1D(HistStruct& hist) :
+		Histogram() {
+	m_binContents.resize(hist.nBins);
+	m_binContents.clear();
+
+	m_squareOfWeights.resize(hist.nBins);
+	m_squareOfWeights.clear();
+
+	m_entries = 0;
+	m_dimensions = 1;
+	m_nBinsX = hist.nBins;
+	m_nBins = hist.nBins;
+	m_xLow = hist.xLow;
+	m_xHigh = hist.xHigh;
+
+	for (int i = 0; i < m_nBins; ++i) {
+
+		m_binContents[i] = hist.contents[i];
+		m_squareOfWeights[i] = hist.sumw2[i];
+	}
+
+	m_entries = hist.entries;
 }
 
-Histogram1D::Histogram1D( int nBins, double xLow, double xHigh,
-                         string name, string title ) :
-Histogram( name, title )
-{
-  m_nBinsX = nBins;
-  m_nBins = nBins;
-  m_xLow= xLow;
-  m_xHigh= xHigh;
-  m_entries= 0;
-  m_dimensions= 1;
-  m_binContents.resize(nBins, 0);
-  m_sumWeightSq.resize(nBins, 0);
-  m_binSizeX = ( xHigh - xLow ) / nBins;
+Histogram1D::Histogram1D(int nBins, double xLow, double xHigh, string name, string title) :
+		Histogram(name, title) {
+	m_nBinsX = nBins;
+	m_nBins = nBins;
+	m_xLow = xLow;
+	m_xHigh = xHigh;
+	m_entries = 0;
+	m_dimensions = 1;
+	m_binContents.resize(nBins);
+	m_binContents.clear();
+	m_squareOfWeights.resize(nBins);
+	m_squareOfWeights.clear();
+
+	m_binSizeX = (xHigh - xLow) / nBins;
 }
 
-void
-Histogram1D::fill( vector < double > values, double weight ){
-  
-  assert (values.size()==1);	//This is a 1D histogram!
-  
-  double value=values.at(0);
-  
-  if( ( value < m_xHigh ) && ( value >= m_xLow ) ){
-    
-    m_binContents[(int)((value - m_xLow)/m_binSizeX)] += weight;
-    m_sumWeightSq[(int)((value - m_xLow)/m_binSizeX)] += weight*weight;
-  }
-  
-  // count overflows and underflows in the number of entries
-  m_entries += weight;
+void Histogram1D::fill(vector<double> values, double weight) {
+
+	assert(values.size() == 1);	//This is a 1D histogram!
+
+	double value = values.at(0);
+
+	if ((value < m_xHigh) && (value >= m_xLow)) {
+		m_binContents[(int) ((value - m_xLow) / m_binSizeX)] += weight;
+		m_squareOfWeights[(int) ((value - m_xLow) / m_binSizeX)] += weight * weight;
+	}
+	// count overflows and underflows in the number of entries
+	m_entries += weight;
 }
 
+TH1* Histogram1D::toRoot(void) const {
 
+	TH1F *plot = new TH1F(name().c_str(), title().c_str(), m_nBins, m_xLow, m_xHigh);
 
+	for (unsigned int i = 0; i < m_binContents.size(); ++i) {
 
-TH1* Histogram1D::toRoot( void ) const {
-  
-  TH1F *plot= new TH1F( name().c_str(), title().c_str(),
-                       m_nBins, m_xLow, m_xHigh );
-  
-  for( unsigned int i = 0; i < m_binContents.size(); ++i ){
-    
-    plot->SetBinContent( i+1, m_binContents[i] );
-    plot->SetBinError( i+1, sqrt( m_sumWeightSq[i] ) );
-  }
-  
-  return (TH1*)plot;
+		plot->SetBinContent(i + 1, m_binContents[i]);
+		plot->SetBinError(i + 1, sqrt(m_squareOfWeights[i]));
+	}
+
+	return (TH1*) plot;
 }
 
-HistStruct
-Histogram1D::toStruct( void ) const {
-  
-  if( m_nBins > MAXBINS ){
-    
-    cout << "Too many bins in histogram -- increase MAXBINS" << endl;
-    assert( false );
-  }
-  
-  HistStruct hist;
-  hist.xLow = m_xLow;
-  hist.xHigh = m_xHigh;
-  hist.nBins = m_nBins;
-  hist.nBinsX = m_nBins;
-  hist.entries = m_entries;
-  
-  for( int i = 0; i < m_nBins; ++i ){
-    
-    hist.contents[i] = static_cast< float >( m_binContents[i] );
-    hist.sumW2[i] = static_cast< float >( m_sumWeightSq[i] );
-  }
-  
-  return hist;
+HistStruct Histogram1D::toStruct(void) const {
+
+	if (m_nBins > MAXBINS) {
+
+		cout << "Too many bins in histogram -- increase MAXBINS" << endl;
+		assert(false);
+	}
+
+	HistStruct hist;
+	hist.xLow = m_xLow;
+	hist.xHigh = m_xHigh;
+	hist.nBins = m_nBins;
+	hist.nBinsX = m_nBins;
+	hist.entries = m_entries;
+
+	for (int i = 0; i < m_nBins; ++i) {
+
+		hist.contents[i] = static_cast<float>(m_binContents[i]);
+		hist.sumw2[i] = static_cast<float>(m_squareOfWeights[i]);
+	}
+
+	return hist;
 }
 
-Histogram* Histogram1D::Clone() const{
-  
-  Histogram* m_histo;
-  m_histo=(Histogram*)(new Histogram1D(*this));
-  return m_histo;
+Histogram* Histogram1D::Clone() const {
+	Histogram* m_histo;
+	m_histo = (Histogram*) (new Histogram1D(*this));
+	return m_histo;
 }

--- a/AmpTools/IUAmpTools/Histogram2D.cc
+++ b/AmpTools/IUAmpTools/Histogram2D.cc
@@ -1,17 +1,17 @@
 //******************************************************************************
 // This file is part of AmpTools, a package for performing Amplitude Analysis
-//
+// 
 // Copyright Trustees of Indiana University 2010, all rights reserved
-//
-// This software written by Matthew Shepherd, Ryan Mitchell, and
+// 
+// This software written by Matthew Shepherd, Ryan Mitchell, and 
 //                  Hrayr Matevosyan at Indiana University, Bloomington
-//
+// 
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
 // are met:
 // 1. Redistributions of source code must retain the above copyright
 //    notice and author attribution, this list of conditions and the
-//    following disclaimer.
+//    following disclaimer. 
 // 2. Redistributions in binary form must reproduce the above copyright
 //    notice and author attribution, this list of conditions and the
 //    following disclaimer in the documentation and/or other materials
@@ -19,18 +19,18 @@
 // 3. Neither the name of the University nor the names of its contributors
 //    may be used to endorse or promote products derived from this software
 //    without specific prior written permission.
-//
+// 
 // Creation of derivative forms of this software for commercial
 // utilization may be subject to restriction; written permission may be
 // obtained from the Trustees of Indiana University.
-//
-// INDIANA UNIVERSITY AND THE AUTHORS MAKE NO REPRESENTATIONS OR WARRANTIES,
-// EXPRESS OR IMPLIED.  By way of example, but not limitation, INDIANA
-// UNIVERSITY MAKES NO REPRESENTATIONS OR WARRANTIES OF MERCANTABILITY OR
-// FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THIS SOFTWARE OR
-// DOCUMENTATION WILL NOT INFRINGE ANY PATENTS, COPYRIGHTS, TRADEMARKS,
-// OR OTHER RIGHTS.  Neither Indiana University nor the authors shall be
-// held liable for any liability with respect to any claim by the user or
+// 
+// INDIANA UNIVERSITY AND THE AUTHORS MAKE NO REPRESENTATIONS OR WARRANTIES, 
+// EXPRESS OR IMPLIED.  By way of example, but not limitation, INDIANA 
+// UNIVERSITY MAKES NO REPRESENTATIONS OR WARRANTIES OF MERCANTABILITY OR 
+// FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THIS SOFTWARE OR 
+// DOCUMENTATION WILL NOT INFRINGE ANY PATENTS, COPYRIGHTS, TRADEMARKS, 
+// OR OTHER RIGHTS.  Neither Indiana University nor the authors shall be 
+// held liable for any liability with respect to any claim by the user or 
 // any other party arising from use of the program.
 //******************************************************************************
 
@@ -43,134 +43,114 @@
 using namespace std;
 
 Histogram2D::Histogram2D() :
-m_nBinsY( 0 ),
-m_yLow( 0 ),
-m_yHigh( 0 )
-{
-  m_dimensions=2;
+		m_nBinsY(0), m_yLow(0), m_yHigh(0) {
+	m_dimensions = 2;
 }
 
-Histogram2D::Histogram2D( HistStruct& hist )
-{
-  
-  m_nBinsX = hist.nBinsX;
-  m_nBinsY = hist.nBinsY;
-  m_xLow = hist.xLow;
-  m_xHigh = hist.xHigh;
-  m_nBinsY = hist.nBinsY;
-  m_yLow = hist.yLow;
-  m_yHigh = hist.yHigh;
-  m_nBins = hist.nBins;
-  m_entries = hist.entries;
-  m_dimensions = 2;
-  m_binContents.resize(m_nBins);
-  m_sumWeightSq.resize(m_nBins);
-  
-  for( int i = 0; i < m_nBins; ++i ){
-    
-    m_binContents[i] = hist.contents[i];
-    m_sumWeightSq[i] = hist.sumW2[i];
-  }
-  
+Histogram2D::Histogram2D(HistStruct& hist) {
+
+	m_nBinsX = hist.nBinsX;
+	m_nBinsY = hist.nBinsY;
+	m_xLow = hist.xLow;
+	m_xHigh = hist.xHigh;
+	m_nBinsY = hist.nBinsY;
+	m_yLow = hist.yLow;
+	m_yHigh = hist.yHigh;
+	m_nBins = hist.nBins;
+	m_binContents.resize(m_nBins);
+	m_binContents.clear();
+	m_squareOfWeights.resize(m_nBins);
+	m_squareOfWeights.clear();
+
+	for (int i = 0; i < m_nBins; ++i) {
+
+		m_binContents[i] = hist.contents[i];
+		m_squareOfWeights[i] = hist.sumw2[i];
+	}
+
+	m_entries = hist.entries;
 }
 
-Histogram2D::Histogram2D( int nBinsX, double xLow, double xHigh,
-                          int nBinsY, double yLow, double yHigh,
-                          string name, string title ) :
-Histogram( name, title )
-{
-  m_xLow=xLow;
-  m_xHigh=xHigh;
-  m_yLow=yLow;
-  m_yHigh=yHigh;
-  m_nBinsX=nBinsX;
-  m_nBinsY=nBinsY;
-  m_nBins=nBinsX*nBinsY;
-  m_dimensions = 2;
-  m_entries=0;
-  m_binContents.resize( nBinsX*nBinsY, 0 );
-  m_sumWeightSq.resize( nBinsX*nBinsY, 0 );
-  m_binSizeX = ( xHigh - xLow ) / nBinsX;
-  m_binSizeY = ( yHigh - yLow ) / nBinsY;
+Histogram2D::Histogram2D(int nBinsX, double xLow, double xHigh, int nBinsY, double yLow, double yHigh, string name, string title) :
+		Histogram(name, title) {
+	m_xLow = xLow;
+	m_xHigh = xHigh;
+	m_yLow = yLow;
+	m_yHigh = yHigh;
+	m_nBinsX = nBinsX;
+	m_nBinsY = nBinsY;
+	m_nBins = nBinsX * nBinsY;
+	m_entries = 0;
+	m_binContents.resize(nBinsX * nBinsY);
+	m_binContents.clear();
+	m_squareOfWeights.resize(nBinsX * nBinsY);
+	m_squareOfWeights.clear();
+
+	m_binSizeX = (xHigh - xLow) / nBinsX;
+	m_binSizeY = (yHigh - yLow) / nBinsY;
 }
 
-void
-Histogram2D::fill(vector < double > values, double weight ){
-  
-  assert (values.size()==2);
-  double valueX=values[0];
-  double valueY=values[1];
+void Histogram2D::fill(vector<double> values, double weight) {
 
-  if( ( valueX < m_xHigh ) && ( valueX >= m_xLow ) && ( valueY < m_yHigh ) && ( valueY >= m_yLow ) ){
-
-    int ibinX=(int)((valueX - m_xLow)/m_binSizeX);
-    int ibinY=(int)((valueY - m_yLow)/m_binSizeY);
-    int ibin=ibinY*m_nBinsX+ibinX; //a-la ROOT
-
-    m_binContents[ibin] += weight;
-    m_sumWeightSq[ibin] += weight*weight;
-  }
-  // count overflows and underflows in the number of entries
-  m_entries += weight;
+	assert(values.size() == 2);
+	double valueX = values[0];
+	double valueY = values[1];
+	if ((valueX < m_xHigh) && (valueX >= m_xLow) && (valueY < m_yHigh) && (valueY >= m_yLow)) {
+		int ibinX = (int) ((valueX - m_xLow) / m_binSizeX);
+		int ibinY = (int) ((valueY - m_yLow) / m_binSizeY);
+		int ibin = ibinY * m_nBinsX + ibinX; //a-la ROOT
+		m_binContents[ibin] += weight;
+		m_squareOfWeights[ibin] += weight * weight;
+	}
+	// count overflows and underflows in the number of entries
+	m_entries += weight;
 }
 
+TH1* Histogram2D::toRoot(void) const {
 
-
-
-TH1* Histogram2D::toRoot( void ) const {
-  
-  TH2F *plot2D=new TH2F( name().c_str(), title().c_str(),
-                         m_nBinsX, m_xLow, m_xHigh,m_nBinsY, m_yLow, m_yHigh );
-  int ibinX,ibinY;
-  for( unsigned int i = 0; i < m_binContents.size(); ++i ){
-    //  int ibin=ibinY*m_nBinsX+ibinX; I used this. So:
-    ibinX=i % m_nBinsX;
-    ibinY=i / m_nBinsX;
-    plot2D->SetBinContent( ibinX+1,ibinY+1, m_binContents[i] );       //+1 since ROOT considers the bin 0-th as underflow.
-    plot2D->SetBinError( ibinX+1,ibinY+1, sqrt( m_sumWeightSq[i] ) );
-  }
-		return plot2D;
+	TH2F *plot2D = new TH2F(name().c_str(), title().c_str(), m_nBinsX, m_xLow, m_xHigh, m_nBinsY, m_yLow, m_yHigh);
+	int ibinX, ibinY;
+	for (unsigned int i = 0; i < m_binContents.size(); ++i) {
+		//  int ibin=ibinY*m_nBinsX+ibinX; I used this. So:
+		ibinX = i % m_nBinsX;
+		ibinY = i / m_nBinsX;
+		plot2D->SetBinContent(ibinX + 1, ibinY + 1, m_binContents[i]);       //+1 since ROOT considers the bin 0-th as underflow.
+		plot2D->SetBinError(ibinX + 1, ibinY + 1, sqrt(m_squareOfWeights[i]));
+	}
+	return plot2D;
 }
 
-HistStruct
-Histogram2D::toStruct( void ) const {
-  
-  if( m_nBins > MAXBINS ){
-    
-    cout << "Too many bins in histogram -- increase MAXBINS" << endl;
-    assert( false );
-  }
-  
-  HistStruct hist2D;
-  hist2D.xLow = m_xLow;
-  hist2D.xHigh = m_xHigh;
-  hist2D.nBinsX = m_nBinsX;
-  
-  hist2D.yLow = m_yLow;
-  hist2D.yHigh = m_yHigh;
-  hist2D.nBinsY = m_nBinsY;
-  
-  hist2D.nBins = m_nBins;
-  
-  hist2D.entries = m_entries;
-  
-  for( int i = 0; i < m_nBins; ++i ){
-    
-    hist2D.contents[i] = static_cast< float >( m_binContents[i] );
-    hist2D.sumW2[i] = static_cast< float >( m_sumWeightSq[i] );
-  }
-  
-  return hist2D;
+HistStruct Histogram2D::toStruct(void) const {
+
+	if (m_nBins > MAXBINS) {
+
+		cout << "Too many bins in histogram -- increase MAXBINS" << endl;
+		assert(false);
+	}
+
+	HistStruct hist2D;
+	hist2D.xLow = m_xLow;
+	hist2D.xHigh = m_xHigh;
+	hist2D.nBinsX = m_nBinsX;
+
+	hist2D.yLow = m_yLow;
+	hist2D.yHigh = m_yHigh;
+	hist2D.nBinsY = m_nBinsY;
+
+	hist2D.nBins = m_nBins;
+
+	hist2D.entries = m_entries;
+
+	for (int i = 0; i < m_nBins; ++i) {
+
+		hist2D.contents[i] = static_cast<float>(m_binContents[i]);
+		hist2D.sumw2[i] = static_cast<float>(m_squareOfWeights[i]);
+	}
+
+	return hist2D;
 }
 
-
-Histogram* Histogram2D::Clone() const{
-  return new Histogram2D(*this);
+Histogram* Histogram2D::Clone() const {
+	return new Histogram2D(*this);
 }
-
-
-
-
-
-
 


### PR DESCRIPTION
Dear AmpTools authors,
since the introduction of 2D histograms that I implemented in AmpTools, I never checked about histogram errors. I made a minimal set of changes to the AmpTools software (Histogram class) in order to properly compute them. The fix is 100% retro-compatible, and the users don't have to change any single line of code in their application to have the new correct calculation working.
Andrea Celentano