### PR TITLE
Synchronize initialization among constraints in ConfigurationInfo.

### DIFF
--- a/AmpTools/IUAmpTools/ConfigFileParser.cc
+++ b/AmpTools/IUAmpTools/ConfigFileParser.cc
@@ -691,18 +691,6 @@ ConfigFileParser::doInitialize(const ConfigFileLine& line){
   if (arguments.size() >= 7) fixtype1 = arguments[6];
   if (arguments.size() == 8) fixtype2 = arguments[7];
   AmplitudeInfo* amplitude = m_configurationInfo->amplitude(reaction,sumname,ampname);
-  initializeAmplitude(amplitude,line,type,value1,value2,fixtype1,fixtype2);
-  vector< AmplitudeInfo* > constraints = amplitude->constraints();
-  for (unsigned int i = 0; i < constraints.size(); i++){
-    initializeAmplitude(constraints[i],line,type,value1,value2,fixtype1,fixtype2);
-  }
-}
-
-
-void
-ConfigFileParser::initializeAmplitude(AmplitudeInfo* amplitude, const ConfigFileLine& line,
-                                      string type, double value1, double value2,
-                                      string fixtype1, string fixtype2){
   if (!amplitude){
     cout << "ConfigFileParser ERROR:  trying to initialize nonexistent amplitude " << endl;
     line.printLine();

--- a/AmpTools/IUAmpTools/ConfigFileParser.h
+++ b/AmpTools/IUAmpTools/ConfigFileParser.h
@@ -227,13 +227,6 @@ class ConfigFileParser
     void doScale         (const ConfigFileLine& line);
 
 
-      // Initialize an amplitude
-
-    void initializeAmplitude(AmplitudeInfo* amplitude, const ConfigFileLine& line,
-                             string type, double value1, double value2,
-                             string fixtype1, string fixtype2);
-
-
       // Member data
 
     string                  m_fitName;

--- a/AmpTools/IUAmpTools/ConfigurationInfo.cc
+++ b/AmpTools/IUAmpTools/ConfigurationInfo.cc
@@ -864,6 +864,33 @@ AmplitudeInfo::addConstraint (AmplitudeInfo* constraint){
   if (!(constraint->hasConstraint(this))) constraint->addConstraint(this);
 }
 
+void
+AmplitudeInfo::setValue (complex<double> value, bool propagateToConstraints){
+  m_value = value;
+  if (!propagateToConstraints) return;
+  for (unsigned int i = 0; i < m_constraints.size(); i++){
+    m_constraints[i]->setValue(value,false);
+  }
+}
+
+void
+AmplitudeInfo::setReal (bool real, bool propagateToConstraints){
+  m_real = real;
+  if (!propagateToConstraints) return;
+  for (unsigned int i = 0; i < m_constraints.size(); i++){
+    m_constraints[i]->setReal(real,false);
+  }
+}
+
+void
+AmplitudeInfo::setFixed (bool fixed, bool propagateToConstraints){
+  m_fixed = fixed;
+  if (!propagateToConstraints) return;
+  for (unsigned int i = 0; i < m_constraints.size(); i++){
+    m_constraints[i]->setFixed(fixed,false);
+  }
+}
+
 
 bool 
 AmplitudeInfo::hasConstraint(AmplitudeInfo* constraint) const{

--- a/AmpTools/IUAmpTools/ConfigurationInfo.h
+++ b/AmpTools/IUAmpTools/ConfigurationInfo.h
@@ -946,10 +946,10 @@ public:
    *
    * \param[in] value the desired initial value
    */
-  void setValue          (complex<double> value)   {m_value = value;}
+  void setValue          (complex<double> value, bool propagateToConstraints = true);
   
-  void setReal           (bool real)               {m_real = real;}
-  void setFixed          (bool fixed)              {m_fixed = fixed;}
+  void setReal           (bool real,  bool propagateToConstraints = true);
+  void setFixed          (bool fixed, bool propagateToConstraints = true);
   
   void setScale          (string scale)            {m_scale = scale;}
 


### PR DESCRIPTION
Synchronize initialization among constraints in ConfigurationInfo instead of ConfigFileParser.