### PR TITLE
fix typo in FitResults.cc file that will cause a crash when one tries…

### DIFF
--- a/AmpTools/IUAmpTools/FitResults.cc
+++ b/AmpTools/IUAmpTools/FitResults.cc
@@ -220,7 +220,7 @@ FitResults::intensity( const vector< string >& amplitudes, bool accCorrected ) c
       
       vector<string> conjAmpNameParts = stringSplit( *conjAmp, "::" );
       assert( conjAmpNameParts.size() == 3 );
-      string conjReaction = ampNameParts[0];
+      string conjReaction = conjAmpNameParts[0];
 
       int jRe = 3 * ( conjAmp - amplitudes.begin() );
       int jIm = jRe + 1;


### PR DESCRIPTION
… to compute the intensity of a list of amplitudes that span multiple reactions