### PR TITLE
Plot fixes for multiple reactions

### DIFF
--- a/AmpPlotter/AmpPlotter/PlotComponentManager.cc
+++ b/AmpPlotter/AmpPlotter/PlotComponentManager.cc
@@ -87,6 +87,10 @@ m_reactionVec( reactionVec )
     genMC->setFillColor(   41 );
     m_genMCGroup->addComponent( genMC );
     m_reactionGroup[i]->addComponent( genMC );
+
+    // enable all reactions by default - this behavior matches that of the
+    // PlotGenerator class in the core AmpTools library
+    enableReaction( i );
   }
   
   
@@ -97,7 +101,6 @@ PlotComponentManager::enableReaction( int index ){
   
   ComponentGroup* group = m_reactionGroup[index];
   
-  //	cout << "Enabling display of reaction:  " << group->title() << endl;
   group->enable();
   m_generator.enableReaction( m_reactionVec[index] );
 }
@@ -107,7 +110,6 @@ PlotComponentManager::disableReaction( int index ){
   
   ComponentGroup* group = m_reactionGroup[index];
   
-  //	cout << "Disabling display of reaction:  " << group->title() << endl;
   group->disable();
   m_generator.disableReaction( m_reactionVec[index] );
 }

--- a/AmpPlotter/AmpPlotter/PlotterMainWindow.cc
+++ b/AmpPlotter/AmpPlotter/PlotterMainWindow.cc
@@ -84,6 +84,7 @@ m_generator( factory.generator() )
                                  ( reaction - reactions.begin() ) | kReaction ) );
 		
     m_reactionButtons.back()->Associate( this );
+    m_reactionButtons.back()->SetState( kButtonDown );
     m_reactionFrame->AddFrame( m_reactionButtons.back(), &reactionLayoutHints );
   }
 	

--- a/AmpPlotter/AmpPlotter/PlotterMainWindow.h
+++ b/AmpPlotter/AmpPlotter/PlotterMainWindow.h
@@ -58,7 +58,7 @@ class PlotterMainWindow : public TGMainFrame
  public:
 	
   enum { kWidth  = 690 };
-  enum { kHeight = 400 };
+  enum { kHeight = 500 };
 	
   enum { kIndexMask     = 0x000000FF };
   enum { kButtonMask    = 0xFFFFFF00 };

--- a/AmpTools/IUAmpTools/FitResults.cc
+++ b/AmpTools/IUAmpTools/FitResults.cc
@@ -160,17 +160,12 @@ FitResults::intensity( const vector< string >& amplitudes, bool accCorrected ) c
       << "***************************************************************" << endl
       << "* WARNING!:  You are calculating an intensity that depends on *" << endl
       << "*   parameters that were floating in the fit.  Unless the par-*" << endl
-      << "*   ameters are amplitude scale factors only, THE ERROR ON    *" << endl
-      << "*   THE INTENSITY SHOULD BE CONSIDERED UNRELIABLE because the *" << endl
-      << "*   software is assuming that the derivatives of the normali- *" << endl
-      << "*   zation integrals with respect to the parameters are equal *" << endl
-      << "*   to zero.  (Fixing this involves numercially computing the *" << endl
-      << "*   derivatives, which will be implemented in future versions *" << endl
-      << "*   of AmpTools.)  For now it is recommended that you repeat  *" << endl
-      << "*   the fit fixing the free parameter(s) at +- 1 sigma of the *" << endl
-      << "*   parameter uncertainty to systematically probe how the     *" << endl
-      << "*   uncertainty on the intensity depends on the uncertainty   *" << endl
-      << "*   of the parameter.                                         *" << endl
+      << "*   ameters are amplitude scale factors only, THE UNCERTAINTY *" << endl
+      << "*   ON THE INTENSITY SHOULD BE CONSIDERED UNRELIABLE because  *" << endl
+      << "*   the calculation assumes that the derivatives of the norm- *" << endl
+      << "*   alization integrals with respect to the parameters are    *" << endl
+      << "*   equal to zero.  Consider using a technique like bootstrap *" << endl
+      << "*   to make a robust estimation of statistical uncertainties. *" << endl
       << "***************************************************************" << endl
       << endl;
       

--- a/AmpTools/IUAmpTools/Histogram1D.cc
+++ b/AmpTools/IUAmpTools/Histogram1D.cc
@@ -35,6 +35,7 @@
 //******************************************************************************
 
 #include <iostream>
+#include <sstream>
 #include <math.h>
 #include <assert.h>
 
@@ -113,6 +114,17 @@ TH1* Histogram1D::toRoot( void ) const {
     plot->SetBinError( i+1, sqrt( m_sumWeightSq[i] ) );
   }
   
+  ostringstream yLabel;
+  yLabel << "Candidates / ";
+  yLabel.precision( 2 );
+  float binSize = ( m_xHigh - m_xLow ) / m_nBins;
+  yLabel << binSize;
+  
+  plot->GetYaxis()->SetTitle( yLabel.str().c_str() );
+  plot->GetXaxis()->SetTitle( title().c_str() );
+  plot->GetXaxis()->SetDecimals();
+  plot->GetXaxis()->SetTitleOffset(1.2);
+
   return (TH1*)plot;
 }
 

--- a/AmpTools/IUAmpTools/PlotGenerator.cc
+++ b/AmpTools/IUAmpTools/PlotGenerator.cc
@@ -133,8 +133,6 @@ m_histTitles( 0 )
           mapItr != m_ampParameters.end();
           ++mapItr ){
         
-        cout << "setting parameter " << mapItr->first << " to " << mapItr->second << endl;
-        
         m_intenManagerMap[reactName]->setParValue( *ampName, mapItr->first, mapItr->second );
       }
     }
@@ -206,7 +204,7 @@ PlotGenerator::~PlotGenerator(){
 }
 
 pair< double, double >
-PlotGenerator::intensity( bool accCorrected ) const {
+PlotGenerator::intensity( const string& reactName, bool accCorrected ) const {
   
   vector< string > enabledAmps;
   
@@ -217,8 +215,9 @@ PlotGenerator::intensity( bool accCorrected ) const {
     
     vector< string > parts = stringSplit( *amp, "::" );
     
-    // be sure the reaction, sum, and amplitude are enabled
-    if( !m_reactEnabled.find( parts[0] )->second ) continue;
+    // be sure the sum and amplitude are enabled for the reaction
+    // that we care about
+    if( reactName != parts[0]  ) continue;
     if( !m_sumEnabled.find( parts[1] )->second ) continue;
     if( !m_ampEnabled.find( parts[2] )->second ) continue;
     
@@ -290,7 +289,8 @@ Histogram* PlotGenerator::projection( unsigned int projectionIndex, string react
     }
     (*cachePtr)[config][reactName] = m_histVect_clone;
     
-    // renormalize MC
+    // renormalize MC - the cache contains one set of plots for each
+    // reaction, so we need to compute intensities for only that reaction
     if( type != kData ){
       
       vector< Histogram* >* histVect = &((*cachePtr)[config][reactName]);
@@ -300,10 +300,10 @@ Histogram* PlotGenerator::projection( unsigned int projectionIndex, string react
         
         switch( type ){
             
-          case kAccMC: (*hist)->normalize( intensity( false ).first );
+          case kAccMC: (*hist)->normalize( intensity( reactName, false ).first );
             break;
             
-          case kGenMC: (*hist)->normalize( intensity( true ).first );
+          case kGenMC: (*hist)->normalize( intensity( reactName, true ).first );
             break;
             
           default:

--- a/AmpTools/IUAmpTools/PlotGenerator.cc
+++ b/AmpTools/IUAmpTools/PlotGenerator.cc
@@ -389,7 +389,7 @@ PlotGenerator::fillProjections( const string& reactName, unsigned int type ){
        
     // the user defines this function in the derived class and it
     // calls the fillHistogram method immediately below
-    projectEvent( kin );
+    projectEvent( kin, reactName );
     
     // cleanup allocated memory
     delete kin;
@@ -667,5 +667,15 @@ PlotGenerator::stringSplit(const string& str, const string& delimiters ) const
   }
   
   return tokens;
+}
+
+void
+PlotGenerator::projectEvent( Kinematics* kin, const string& reaction ){
+  
+  // by default this function calls projectEvent without the reaction name
+  // in some instances (plotting of multiple reactions simultaneously) one
+  // may wish to override this function and do reaction-dependent plotting
+  
+  projectEvent( kin );
 }
 

--- a/AmpTools/IUAmpTools/PlotGenerator.h
+++ b/AmpTools/IUAmpTools/PlotGenerator.h
@@ -68,8 +68,10 @@ public:
 
   virtual ~PlotGenerator();
   
-  // get intensity for all amplitudes that are turned on
-  pair< double, double > intensity( bool accCorrected = true ) const;
+  // get intensity for all amplitudes that are turned on for
+  // a specific reaction
+  pair< double, double > intensity( const string& reactName,
+                                    bool accCorrected = true ) const;
   
   bool haveAmp( const string& amp ) const;
   

--- a/AmpTools/IUAmpTools/PlotGenerator.h
+++ b/AmpTools/IUAmpTools/PlotGenerator.h
@@ -121,9 +121,17 @@ protected:
  
 private:
  
-  // this function should be overridden by the derived class
-  // that is written by the user
-  virtual void projectEvent( Kinematics* kin ) = 0;
+  // this function can be overridden by the derived class
+  // that is written by the user; if the projections are
+  // reaction dependent, then the user should override the
+  // function below this one
+  virtual void projectEvent( Kinematics* kin ){}
+  
+  // provide this function for the user to override in case the
+  // projection is reaction dependent; by default this function
+  // will just call the function above, but by overriding it
+  // the user may customize the behavior
+  virtual void projectEvent( Kinematics* kin, const string& reaction );
   
   void clearHistograms();
   void fillProjections( const string& reactName, unsigned int type );


### PR DESCRIPTION
This merge makes a number of changes to enhance plotting and management of multiple reactions simultaneously:

* unify initial state of GUI, PlotComponentManager, and PlotGenerator so that all reactions are enabled by default
* adjust height of plotter window to avoid crowding
* improved labels on axes of 1D histograms
* suppressed some debugging output to screen and more accurate warning messages
* correct normalization of MC histograms in the case of multiple reactions
* add new projectEvent method to PlotGenerator class that enables the user to make reaction-dependent projections; modify existing methods to try to ensure backwards compatibility
