### PR TITLE
ATI memory fix

### DIFF
--- a/AmpPlotter/AmpPlotter/Makefile
+++ b/AmpPlotter/AmpPlotter/Makefile
@@ -9,7 +9,7 @@ default: $(LIB)
 	$(Q)ar -rsc $@ $^
 
 %.o : %.cc
-	$(vecho) "-> Compiling $@"
+	$(vecho) "-> Compiling $<"
 	$(Q)$(CXX) $(CXX_FLAGS) -M -o $*.d $< $(INC_DIR) ; \
 	cp $*.d $*.dep; \
 	sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \

--- a/AmpPlotter/Makefile
+++ b/AmpPlotter/Makefile
@@ -22,6 +22,7 @@ DEFAULT := libAmpPlotter.a
 export
 
 .PHONY: default clean
+.PRECIOUS: %.o
 
 default: lib $(DEFAULT)
 

--- a/AmpTools/IUAmpTools/AmpToolsInterface.cc
+++ b/AmpTools/IUAmpTools/AmpToolsInterface.cc
@@ -384,11 +384,16 @@ AmpToolsInterface::clear(){
       string reactionName(reaction->reactionName());
       
       if (likelihoodCalculator(reactionName)) delete m_likCalcMap[reactionName];
-      if (intensityManager(reactionName)) delete intensityManager(reactionName);
       if (dataReader(reactionName)) delete dataReader(reactionName);
       if (accMCReader(reactionName)) delete accMCReader(reactionName);
       if (genMCReader(reactionName)) delete genMCReader(reactionName);
       if (normIntInterface(reactionName)) delete normIntInterface(reactionName);
+    }
+
+    // logic above won't work for these since the lookup function for each reaction
+    // depends on the reaction itself
+    for (unsigned int i = 0; i < m_intensityManagers.size(); i++){
+      delete m_intensityManagers[i];
     }
   }
   


### PR DESCRIPTION
This fixes bug in the AmpToolsInterface that led to accessing memory after it was freed and sometimes resulted in a crash at program exit.  This bug would not affect fit results, but would cause problems anytime the clear() function of AmpToolsInterface was called with multiple reactions defined.