### PR TITLE
Random prod pars

### DIFF
--- a/AmpTools/IUAmpTools/AmpToolsInterface.cc
+++ b/AmpTools/IUAmpTools/AmpToolsInterface.cc
@@ -335,14 +335,8 @@ AmpToolsInterface::finalizeFit( const string& tag ){
   // save fit parameters
   // ************************
   
-  string fitName = m_configurationInfo->fitName();
-  string ext( ".fit" );
-  if( tag.size() != 0 ) fitName += string( "_" ) + tag;
-  string outputFile = fitName + ext;
-  
-  ofstream outFile(outputFile.c_str());
   m_fitResults->saveResults();
-  m_fitResults->writeResults( outputFile );
+  m_fitResults->writeResults( m_configurationInfo->fitOutputFileName( tag ) );
   
   // ************************
   // save normalization integrals

--- a/AmpTools/IUAmpTools/AmpToolsInterface.cc
+++ b/AmpTools/IUAmpTools/AmpToolsInterface.cc
@@ -51,6 +51,7 @@
 
 vector<Amplitude*> AmpToolsInterface::m_userAmplitudes;
 vector<DataReader*> AmpToolsInterface::m_userDataReaders;
+unsigned int AmpToolsInterface::m_randomSeed = 0;
 
 AmpToolsInterface::AmpToolsInterface( FunctionalityFlag flag ) :
 m_functionality( flag ),
@@ -59,7 +60,7 @@ m_minuitMinimizationManager(NULL),
 m_parameterManager(NULL),
 m_fitResults(NULL)
 {
-  
+  srand( m_randomSeed );
 }
 
 
@@ -71,7 +72,7 @@ m_parameterManager(NULL),
 m_fitResults(NULL){
   
   resetConfigurationInfo(configurationInfo);
-  
+  srand( m_randomSeed );
 }
 
 
@@ -264,19 +265,56 @@ AmpToolsInterface::likelihood () const {
   return L;
 }
 
+void
+AmpToolsInterface::randomizeProductionPars( float maxFitFraction ){
+  
+  // shouldn't be callin' unless you're fittin'
+  if( m_functionality != kFull ) return;
+  
+  vector< AmplitudeInfo* > amps = m_configurationInfo->amplitudeList();
+    
+  for( vector< AmplitudeInfo* >::iterator ampItr = amps.begin();
+      ampItr != amps.end();
+      ++ampItr ){
+   
+    if( (**ampItr).fixed() ) continue;
+    
+    string ampName = (**ampItr).fullName();
+    string reac = (**ampItr).reactionName();
+  
+    double numSignalEvents = likelihoodCalculator(reac)->numSignalEvents();
+    double normInt = normIntInterface(reac)->normInt(ampName,ampName).real();
+    double ampScale = intensityManager(reac)->getScale(ampName);
+    
+    // fit fraction = ( scale^2 * prodPar^2 * normInt ) / numSignalEvents
+    
+    double fitFraction = random( maxFitFraction );
+    double prodParMag = sqrt( ( numSignalEvents * fitFraction ) /
+                              ( ampScale * ampScale * normInt ) );
+    double prodParPhase = ( (**ampItr).real() ? 0 : random( 2*PI ) );
+    
+    complex< double > prodPar( prodParMag*cos( prodParPhase ),
+                              prodParMag*sin( prodParPhase ) );
+    
+    m_parameterManager->setProductionParameter( ampName, prodPar );
+  }
+}
 
 void
-AmpToolsInterface::finalizeFit(){
+AmpToolsInterface::finalizeFit( const string& tag ){
   
   // ************************
   // save fit parameters
   // ************************
   
-  string outputFile(m_configurationInfo->fitOutputFileName());
+  string fitName = m_configurationInfo->fitName();
+  string ext( ".fit" );
+  if( tag.size() != 0 ) fitName += string( "_" ) + tag;
+  string outputFile = fitName + ext;
+  
   ofstream outFile(outputFile.c_str());
   m_fitResults->saveResults();
   m_fitResults->writeResults( outputFile );
-  
   
   // ************************
   // save normalization integrals
@@ -296,7 +334,6 @@ AmpToolsInterface::finalizeFit(){
     }
   }
 }
-
 
 IntensityManager*
 AmpToolsInterface::intensityManager(const string& reactionName) const {
@@ -741,4 +778,10 @@ AmpToolsInterface::printEventDetails(string reactionName, Kinematics* kin) const
   printAmplitudes(reactionName,kin);
   printIntensity(reactionName,kin);
   
+}
+
+float
+AmpToolsInterface::random( float randMax ){
+  
+  return ( (float) rand() / RAND_MAX ) * randMax;
 }

--- a/AmpTools/IUAmpTools/AmpToolsInterface.cc
+++ b/AmpTools/IUAmpTools/AmpToolsInterface.cc
@@ -301,6 +301,34 @@ AmpToolsInterface::randomizeProductionPars( float maxFitFraction ){
 }
 
 void
+AmpToolsInterface::randomizeParameter( const string& parName, float min, float max ){
+
+  vector<ParameterInfo*> parInfoVec = m_configurationInfo->parameterList();
+
+  auto parItr = parInfoVec.begin();
+  for( ; parItr != parInfoVec.end(); ++parItr ){
+    
+    if( (**parItr).parName() == parName ) break;
+  }
+  
+  if( parItr == parInfoVec.end() ){
+    
+    cout << "ERROR:  request to randomize nonexistent parameter:  " << parName << endl;
+    return;
+  }
+  
+  if( (**parItr).fixed() ){
+    
+    cout << "ERROR:  request to randomize a parameter named " << parName
+         << " that is fixed.  Ignoring." << endl;
+    return;
+  }
+  
+  double value = min + random( max - min );
+  m_parameterManager->setAmpParameter( parName, value );
+}
+
+void
 AmpToolsInterface::finalizeFit( const string& tag ){
   
   // ************************

--- a/AmpTools/IUAmpTools/AmpToolsInterface.h
+++ b/AmpTools/IUAmpTools/AmpToolsInterface.h
@@ -234,6 +234,15 @@ class AmpToolsInterface{
 
   void randomizeProductionPars( float maxFitFraction = 1 );
   
+  /** This function will fill the value of a parameter named parName with
+   * a randon number between min (0 default) and max (1 default).  The parName
+   * should be the name of a parameter declared in the config file using
+   * the parameter keyword.  This function is not able to modify parameters
+   * that are production coefficients of amplitudes.
+   */
+  
+  void randomizeParameter( const string& parName, float min = 0, float max = 1 );
+
   /** Print final fit results to a file.  The tag can be used to
    *  generate a unique name in the case that multiple results are
    *  written for a singele fit job.

--- a/AmpTools/IUAmpTools/AmpToolsInterface.h
+++ b/AmpTools/IUAmpTools/AmpToolsInterface.h
@@ -120,6 +120,8 @@ class AmpToolsInterface{
 
     static void registerDataReader( const DataReader& defaultDataReader);
 
+  static void setRandomSeed( unsigned int seed ) { m_randomSeed = seed; }
+  
   /** Use this method to re-initialize all IUAmpTools classes based on information
    *  in a new or modified ConfigurationInfo object.
    */
@@ -222,11 +224,22 @@ class AmpToolsInterface{
 
     double likelihood(const string& reactionName) const;
 
-
-  /** Print final fit results to a file.
+  /** This function will randomly set the production parameters in
+   * the likelihood calculator.  It is useful when searching for multiple
+   * ambiguous solutions.  Production parameters will be set such that
+   * starting fit fraction varies between zero and fraction specified
+   * by the optional argument.  The phase will be set randomly between
+   * zero and 2 pi.
    */
 
-    virtual void finalizeFit();
+  void randomizeProductionPars( float maxFitFraction = 1 );
+  
+  /** Print final fit results to a file.  The tag can be used to
+   *  generate a unique name in the case that multiple results are
+   *  written for a singele fit job.
+   */
+
+    virtual void finalizeFit( const string& tag = "" );
 
 
   /** For manual calculations:  clear all events and calculations.
@@ -424,12 +437,20 @@ class AmpToolsInterface{
 
     static vector<Amplitude*>  m_userAmplitudes;
     static vector<DataReader*> m_userDataReaders;
+  
+  static unsigned int m_randomSeed;
+  
+  // these variables are used in cases where the AmpToolsInterface
+  // most provide a place to load the data -- during normal
+  // fitting the data are 
 
     static const int MAXAMPVECS = 50;
     AmpVecs m_ampVecs[MAXAMPVECS];
     string  m_ampVecsReactionName[MAXAMPVECS];
    
     FitResults* m_fitResults;
+  
+    float random( float randMax );
 
 };
 

--- a/AmpTools/IUAmpTools/ConfigurationInfo.cc
+++ b/AmpTools/IUAmpTools/ConfigurationInfo.cc
@@ -53,6 +53,15 @@ ConfigurationInfo::~ConfigurationInfo(){
   removeReaction();
 }
 
+string
+ConfigurationInfo::fitOutputFileName( const string& tag ) const {
+  
+  string fitName = m_fitName;
+  if( tag.size() != 0 ) fitName += string( "_" ) + tag;
+  string ext( ".fit" );
+  
+  return fitName + ext;
+}
 
 vector< string >
 ConfigurationInfo::userKeywords() const{

--- a/AmpTools/IUAmpTools/ConfigurationInfo.h
+++ b/AmpTools/IUAmpTools/ConfigurationInfo.h
@@ -137,8 +137,7 @@ public:
   /**
    * Name of the fit results file.
    */
-  string fitOutputFileName() const { return m_fitName + ".fit"; }
-
+  string fitOutputFileName( const string& tag = "" ) const;
 
   /**
    * A list of user-defined keywords.

--- a/AmpTools/IUAmpTools/FitResults.cc
+++ b/AmpTools/IUAmpTools/FitResults.cc
@@ -746,6 +746,8 @@ FitResults::writeSeed( const string& outFile ) const {
     if( parInfo->gaussianBounded() )
       output << " gaussian " << parInfo->centralValue()
            << " " << parInfo->gaussianError();
+    
+    output << endl;
   }
 }
 

--- a/AmpTools/IUAmpTools/LikelihoodCalculator.cc
+++ b/AmpTools/IUAmpTools/LikelihoodCalculator.cc
@@ -99,7 +99,7 @@ LikelihoodCalculator::operator()(){
 double
 LikelihoodCalculator::numSignalEvents(){
 
-  if( !m_firstDataCalc ) dataTerm();
+  if( m_firstDataCalc ) dataTerm();
   return numDataEvents() - sumBkgWeights();
 }
 

--- a/AmpTools/IUAmpTools/LikelihoodCalculator.cc
+++ b/AmpTools/IUAmpTools/LikelihoodCalculator.cc
@@ -96,6 +96,13 @@ LikelihoodCalculator::operator()(){
   return -2 * ( dataTerm() - normIntTerm() );
 }
 
+double
+LikelihoodCalculator::numSignalEvents(){
+
+  if( !m_firstDataCalc ) dataTerm();
+  return numDataEvents() - sumBkgWeights();
+}
+
 
 double
 LikelihoodCalculator::normIntTerm(){

--- a/AmpTools/IUAmpTools/LikelihoodCalculator.h
+++ b/AmpTools/IUAmpTools/LikelihoodCalculator.h
@@ -84,6 +84,8 @@ public:
   // this method delivers the likelihood
   double operator()();
   
+  double numSignalEvents() const { return numDataEvents() - sumBkgWeights(); }
+  
 protected:
   
   // helper functions -- also useful for pulling parts of the

--- a/AmpTools/IUAmpTools/LikelihoodCalculator.h
+++ b/AmpTools/IUAmpTools/LikelihoodCalculator.h
@@ -84,7 +84,7 @@ public:
   // this method delivers the likelihood
   double operator()();
   
-  double numSignalEvents() const { return numDataEvents() - sumBkgWeights(); }
+  double numSignalEvents();
   
 protected:
   

--- a/AmpTools/IUAmpTools/NormIntInterface.cc
+++ b/AmpTools/IUAmpTools/NormIntInterface.cc
@@ -336,8 +336,11 @@ NormIntInterface::forceCacheUpdate( bool normIntOnly ) const
     return;
   }
   
-  if( !normIntOnly ){
-  
+  // we only need to recalculate the generated MC integrals if we haven't
+  // done it yet or there are floating paramters in the amplitude
+  if( !normIntOnly &&
+      ( m_emptyAmpIntCache || m_pIntenManager->hasTermWithFreeParam() ) ){
+      
     // now we need to have the generated MC in addition to the accepted
     // MC in order to be able to continue
     assert( m_genMCReader != NULL );

--- a/AmpTools/IUAmpTools/ParameterManager.cc
+++ b/AmpTools/IUAmpTools/ParameterManager.cc
@@ -71,7 +71,7 @@ m_intenManagers( intenManagers )
 }
 
 // protected constructors: these are used in MPI implementations where
-// the ParameterManager is created on a worker node that does not have
+// the ParameterManager is created on a follower node that does not have
 // a MinuitMinimizationManager.  The reference must be initialized, so
 // it is initialized to NULL but never used.  The class using these
 // constructors must override any method that uses the

--- a/AmpTools/IUAmpTools/ParameterManager.cc
+++ b/AmpTools/IUAmpTools/ParameterManager.cc
@@ -158,6 +158,23 @@ ParameterManager::setProductionParameter( const string& termName,
   findParameter(termName)->setValue(prodPar);
 }
 
+void
+ParameterManager::setAmpParameter( const string& parName,
+                                   double value ){
+
+  map< string, MinuitParameter* > m_ampParams;
+
+  auto ampParItr = m_ampParams.find( parName );
+  
+  if( ampParItr == m_ampParams.end() ){
+    
+    cout << "ERROR:  request to set value of unkown parameter named "
+         << parName << " -- ignoring request." << endl;
+    return;
+  }
+  
+  ampParItr->second->setValue( value );
+}
 
 void
 ParameterManager::addAmplitudeParameter( const string& termName, const ParameterInfo* parInfo ){

--- a/AmpTools/IUAmpTools/ParameterManager.cc
+++ b/AmpTools/IUAmpTools/ParameterManager.cc
@@ -162,8 +162,6 @@ void
 ParameterManager::setAmpParameter( const string& parName,
                                    double value ){
 
-  map< string, MinuitParameter* > m_ampParams;
-
   auto ampParItr = m_ampParams.find( parName );
   
   if( ampParItr == m_ampParams.end() ){
@@ -173,7 +171,11 @@ ParameterManager::setAmpParameter( const string& parName,
     return;
   }
   
-  ampParItr->second->setValue( value );
+  // the "false" here disables notifications that
+  // parameters have changed -- this avoids undesirable
+  // behavior when trying to setup a fit, which is what
+  // this member function is used for
+  ampParItr->second->setValue( value, false );
 }
 
 void

--- a/AmpTools/IUAmpTools/ParameterManager.cc
+++ b/AmpTools/IUAmpTools/ParameterManager.cc
@@ -151,6 +151,13 @@ ParameterManager::setupFromConfigurationInfo( ConfigurationInfo* cfgInfo ){
   }
 }
 
+void
+ParameterManager::setProductionParameter( const string& termName,
+                                          complex< double > prodPar ){
+  
+  findParameter(termName)->setValue(prodPar);
+}
+
 
 void
 ParameterManager::addAmplitudeParameter( const string& termName, const ParameterInfo* parInfo ){
@@ -163,9 +170,7 @@ ParameterManager::addAmplitudeParameter( const string& termName, const Parameter
   MinuitParameter* parPtr;
   
   if( mapItr == m_ampParams.end() ){
-    
-//    cout << "Creating new amplitude parameter:  " << parInfo->parName() << endl;
-    
+        
     parPtr = new MinuitParameter( parName, m_minuitManager->parameterManager(),
                                  parInfo->value());
     

--- a/AmpTools/IUAmpTools/ParameterManager.h
+++ b/AmpTools/IUAmpTools/ParameterManager.h
@@ -72,6 +72,9 @@ public:
   
   void setupFromConfigurationInfo( ConfigurationInfo* cfgInfo );
     
+  void setProductionParameter( const string& termName,
+                               complex< double > prodPar );
+  
   // these functions provide a list of all known parameters, including those that are
   // constrained to other parameters in addition to a covariance matrix that
   // incorporates those constraints

--- a/AmpTools/IUAmpTools/ParameterManager.h
+++ b/AmpTools/IUAmpTools/ParameterManager.h
@@ -93,7 +93,7 @@ public:
   
 protected:
   
-  // MPI implementations on the worker nodes need to be able
+  // MPI implementations on the follower nodes need to be able
   // to create a ParameterManager without attaching it to
   // a MinuitMinimizationManager - no one else should be using
   // these constructors.  Use of these constructors requires

--- a/AmpTools/IUAmpTools/ParameterManager.h
+++ b/AmpTools/IUAmpTools/ParameterManager.h
@@ -74,6 +74,7 @@ public:
     
   void setProductionParameter( const string& termName,
                                complex< double > prodPar );
+  void setAmpParameter( const string& parName, double value );
   
   // these functions provide a list of all known parameters, including those that are
   // constrained to other parameters in addition to a covariance matrix that

--- a/AmpTools/IUAmpTools/PlotGenerator.cc
+++ b/AmpTools/IUAmpTools/PlotGenerator.cc
@@ -72,7 +72,12 @@ m_histTitles( 0 )
     
     m_ampIndex[amps[i]] = i;
     
-    // keep vector with orginal fit values
+    // keep vector with orginal fit values (Note: that these are unscaled
+    // production parameters.  In the case that an amplitude has a fixed
+    // scale that scale will be loaded when the intensity manager is
+    // set up.  If the amplitude has a scale given by a parameter, then
+    // the loop below that sets the parameters to their fit values will
+    // take care of that.)
     m_fitProdAmps.push_back( m_fitResults.productionParameter( amps[i] ) );
 
     // a parallel vector of zeros

--- a/AmpTools/IUAmpToolsMPI/AmpToolsInterfaceMPI.cc
+++ b/AmpTools/IUAmpToolsMPI/AmpToolsInterfaceMPI.cc
@@ -157,22 +157,44 @@ AmpToolsInterfaceMPI::AmpToolsInterfaceMPI(ConfigurationInfo* configurationInfo)
                                  m_minuitMinimizationManager,
                                  m_parameterManager );
 
-
-  if (m_rank != 0) LikelihoodManagerMPI::deliverLikelihood();
-
+  if (m_rank != 0){
+    
+    // the followers should be ready to fit and finalize the fit in successsion
+    while( LikelihoodManagerMPI::lastCommand() !=
+           LikelihoodManagerMPI::kExit ){
+  
+      LikelihoodManagerMPI::deliverLikelihood();
+      if( LikelihoodManagerMPI::lastCommand() == LikelihoodManagerMPI::kFinalizeFit )
+        finalizeFit();
+    }
+  }
 }
 
+void AmpToolsInterfaceMPI::exitMPI(){
+  
+  // exit should be called prior to the AmpToolsInterfaceMPI object
+  // going out of scope, being destroyed, or MPI_Finalize() being called
+  
+  if (m_rank == 0){
 
-
-
+    for (unsigned int irct = 0;
+         irct < m_configurationInfo->reactionList().size(); irct++){
+      ReactionInfo* reaction = m_configurationInfo->reactionList()[irct];
+      string reactionName(reaction->reactionName());
+      if (m_likCalcMap.find(reactionName) != m_likCalcMap.end())
+        delete m_likCalcMap[reactionName];
+      m_likCalcMap.erase(reactionName);
+    }
+  }
+}
 
 void
-AmpToolsInterfaceMPI::finalizeFit(){
+AmpToolsInterfaceMPI::finalizeFit( const string& tag ){
 
   if (m_rank != 0){
 
-    // this forceCacheUpdate on the workers executes simultaneously with the
-    // same call in FitResults::writeResults on the master
+    // this forceCacheUpdate on the followers executes simultaneously with the
+    // same call in FitResults::writeResults on the leader
 
     for (unsigned int irct = 0; irct < m_configurationInfo->reactionList().size(); irct++){
       ReactionInfo* reaction = m_configurationInfo->reactionList()[irct];
@@ -188,31 +210,27 @@ AmpToolsInterfaceMPI::finalizeFit(){
       // save fit parameters
       // ************************
 
-    string outputFile(m_configurationInfo->fitOutputFileName());
-    ofstream outFile(outputFile.c_str());
     m_fitResults->saveResults();
  
-    // after saving the results destroy the LikelihoodCalculatorMPI
-    // class on the master -- this will break the worker nodes out
-    // of their deliverLikelihood loop and let them enter this routine
+    // after saving the results trigger the follower classes
+    // to finalize the fit so they will end up in this function
 
     for (unsigned int irct = 0;
          irct < m_configurationInfo->reactionList().size(); irct++){
       ReactionInfo* reaction = m_configurationInfo->reactionList()[irct];
       string reactionName(reaction->reactionName());
       if (m_likCalcMap.find(reactionName) != m_likCalcMap.end())
-        delete m_likCalcMap[reactionName];
-      m_likCalcMap.erase(reactionName);
+        dynamic_cast<LikelihoodCalculatorMPI*>(m_likCalcMap[reactionName])->finalizeFit();
     }
 
-    m_fitResults->writeResults( outputFile );
+    m_fitResults->writeResults( m_configurationInfo->fitOutputFileName( tag ) );
  }
  
    // ************************
    // save normalization integrals
    // ************************
 
-  // this runs on both the workers and the masters simultaneously
+  // this runs on both the followers and the leader simultaneously
 
   for (unsigned int irct = 0; irct < m_configurationInfo->reactionList().size(); irct++){
 

--- a/AmpTools/IUAmpToolsMPI/AmpToolsInterfaceMPI.h
+++ b/AmpTools/IUAmpToolsMPI/AmpToolsInterfaceMPI.h
@@ -6,18 +6,23 @@
 using namespace std;
 
 class AmpToolsInterfaceMPI : public AmpToolsInterface{
+  
+public:
+  
+  AmpToolsInterfaceMPI(ConfigurationInfo* cfgInfo);
+  ~AmpToolsInterfaceMPI(){}
+  
+  void finalizeFit( const string& tag = "" );
 
-  public:
-
-    AmpToolsInterfaceMPI(ConfigurationInfo* cfgInfo);
-
-    void finalizeFit();
-
-  private:
-
-    int m_rank;
-    int m_numProc;
-
+  // exit MPI should be called on the leader process before
+  // MPI_Finalize() or variables go out of scope
+  void exitMPI();
+  
+private:
+  
+  int m_rank;
+  int m_numProc;
+  
 };
 
 

--- a/AmpTools/IUAmpToolsMPI/LikelihoodCalculatorMPI.h
+++ b/AmpTools/IUAmpToolsMPI/LikelihoodCalculatorMPI.h
@@ -74,10 +74,10 @@ class LikelihoodCalculatorMPI : public LikelihoodCalculator
 
   /**
    * This is the constructor.  On all nodes setupMPI() is called first to
-   * define the rank and number of processes.  On the woker nodes, each
+   * define the rank and number of processes.  On the follower nodes, each
    * instance of LikelihoodCalulatorMPI registers itself with the 
-   * LikelihoodManagerMPI.  Each instance on the worker nodes has a unique
-   * ID which is derived from the cuerrent value of the static member data
+   * LikelihoodManagerMPI.  Each instance on the follower nodes has a unique
+   * ID which is derived from the current value of the static member data
    * m_idCounter.
    *
    * Arguments to this constructor are similar to those for LikelihoodCalculator.
@@ -104,30 +104,37 @@ class LikelihoodCalculatorMPI : public LikelihoodCalculator
   
   /**
    * This is the destructor.  When the instance of LikelihoodCalculatorMPI
-   * is destroyed on the master node, it sends the exit flag (via the
+   * is destroyed on the leader node, it sends the exit flag (via the
    * LikelihoodManagerMPI) to the corresponding LikelihoodCalculatorMPI that
-   * exists on the worker nodes.
+   * exists on the follower nodes.
    */
   
   ~LikelihoodCalculatorMPI();
 
   /**
-   * The following operator should only ever be called on the master.  It 
+   * The following operator should only ever be called on the leader.  It
    * overrides the operator()() that is called from MIFunctionContribution class.
-   * Using the LikelihoodManagerMPI, it directs all of the workers to compute
+   * Using the LikelihoodManagerMPI, it directs all of the followers to compute
    * and then send partial contributions of the sum of log intensities.  The
-   * routine on the master collects and sums the contributions from the workers.
+   * routine on the leader collects and sums the contributions from the followers.
    * It then, if necessary, triggers an update of the normalization integral 
-   * calculculation on the workers.  Finally it provides the new 
+   * calculculation on the followers.  Finally it provides the new
    * -2 ln( likelihood ) for the fit.
    */
   double operator()();
+  
+  /**
+   * This sends the finalize fit flag to all follower jobs which breaks them
+   * out of the deliverLikelihood method of the LikelihoodManagerMPI.
+   */
+  
+  void finalizeFit();
   
 private:
 
   // the following functions are used by the LikelihoodManager to trigger
   // portions of the likeihood calculation -- they should only be called
-  // on the worker nodes
+  // on the follower nodes
   void updateParameters();
   void updateAmpParameter();
   void computeLikelihood();
@@ -143,7 +150,7 @@ private:
 
   int m_rank;
   int m_numProc;
-  bool m_isMaster;
+  bool m_isLeader;
   bool m_firstPass;
 };
 

--- a/AmpTools/IUAmpToolsMPI/LikelihoodManagerMPI.cc
+++ b/AmpTools/IUAmpToolsMPI/LikelihoodManagerMPI.cc
@@ -115,9 +115,7 @@ LikelihoodManagerMPI::deliverLikelihood()
              MPI_COMM_WORLD, &status );
   }
 
-  m_lastCommand = *fitFlag;
-
-  assert( m_lastCommand == kExit || m_lastCommand == kFinalizeFit );
+  m_lastCommand = static_cast<LikelihoodManagerMPI::FitCommand>(*fitFlag);
 }
 
 void
@@ -168,4 +166,4 @@ int LikelihoodManagerMPI::m_numProc = 0;
 map< int, LikelihoodCalculatorMPI* > LikelihoodManagerMPI::m_calcMap;
 
 // it is OK to intialize this to anything but kExit
-FitCommand LikelihoodManagerMPI::m_lastCommand = kComputeLikelihood;
+LikelihoodManagerMPI::FitCommand LikelihoodManagerMPI::m_lastCommand = kComputeLikelihood;

--- a/AmpTools/IUAmpToolsMPI/LikelihoodManagerMPI.h
+++ b/AmpTools/IUAmpToolsMPI/LikelihoodManagerMPI.h
@@ -63,7 +63,7 @@ class LikelihoodManagerMPI
   
   static void broadcastToFirst( FitCommand command );
   
-  static FitCommand lastCommand() const { return m_lastCommand; }
+  static FitCommand lastCommand() { return m_lastCommand; }
   
  private:
 

--- a/AmpTools/IUAmpToolsMPI/LikelihoodManagerMPI.h
+++ b/AmpTools/IUAmpToolsMPI/LikelihoodManagerMPI.h
@@ -52,6 +52,7 @@ class LikelihoodManagerMPI
                     kComputeIntegrals,
                     kUpdateParameters,
                     kUpdateAmpParameter,
+                    kFinalizeFit,
                     kExit };
 
   LikelihoodManagerMPI(){};
@@ -62,15 +63,18 @@ class LikelihoodManagerMPI
   
   static void broadcastToFirst( FitCommand command );
   
+  static FitCommand lastCommand() const { return m_lastCommand; }
+  
  private:
 
   static void setupMPI();
 
   static bool m_mpiSetup;
-  static bool m_isMaster;
+  static bool m_isLeader;
   static int m_numProc;
 
   static map< int, LikelihoodCalculatorMPI* > m_calcMap;
+  static FitCommand m_lastCommand;
 };
 
 #endif

--- a/AmpTools/IUAmpToolsMPI/LikelihoodManagerMPI.h
+++ b/AmpTools/IUAmpToolsMPI/LikelihoodManagerMPI.h
@@ -43,6 +43,14 @@ class LikelihoodCalculatorMPI;
 
 using namespace std;
 
+/*
+ There is one instance of this class per MPI job and it manages what could
+ be multiple LikelihoodCalculators (one for each reaction) within a single
+ MPI job.  All LikelihoodCalculators that are created within the job
+ register with this class.  The behavior of the instance varies depending on
+ whether the MPI job is the leader or follower job.
+ */
+
 class LikelihoodManagerMPI
 {
   

--- a/AmpTools/IUAmpToolsMPI/NormIntInterfaceMPI.h
+++ b/AmpTools/IUAmpToolsMPI/NormIntInterfaceMPI.h
@@ -67,7 +67,7 @@ private:
   
   int m_rank;
   int m_numProc;
-  bool m_isMaster;
+  bool m_isLeader;
 };
 
 #endif

--- a/AmpTools/IUAmpToolsMPI/ParameterManagerMPI.h
+++ b/AmpTools/IUAmpToolsMPI/ParameterManagerMPI.h
@@ -56,7 +56,7 @@ public:
   enum { kMaxNameLength = 200 };
   
   // since there is only one MinuitMinimizationManager we must add
-  // an additional constructor for the worker nodes
+  // an additional constructor for the follower nodes
   
   // this constructor is called on the head node
   ParameterManagerMPI( MinuitMinimizationManager* minuitManager,
@@ -64,14 +64,14 @@ public:
   ParameterManagerMPI( MinuitMinimizationManager* minuitManager,
                       const vector< IntensityManager* >& intenManagers );
   
-  // this constructor should be called on the worker nodes
+  // this constructor should be called on the follower nodes
   ParameterManagerMPI( IntensityManager* intenManager );
   ParameterManagerMPI( const vector< IntensityManager* >& intenManagers );
   
   ~ParameterManagerMPI();
   
   // override these functions to do the appropriate thing depending
-  // on whether this instance is on the head or worker node
+  // on whether this instance is on the head or follower node
   void addProductionParameter( const string& termName, bool real = false, bool fixed = false );
   void addAmplitudeParameter( const string& termName, const ParameterInfo* parInfo );
   
@@ -79,9 +79,9 @@ public:
   // to update the parameters in advance of the likelihood calculation
   void updateParameters();
   
-  // the likelihood calculator on the worker nodes will call this routine
+  // the likelihood calculator on the follower nodes will call this routine
   // in order to update a changed ampitude parameter -- the update routine
-  // on the master (function below) will call this directly with the
+  // on the leader (function below) will call this directly with the
   // parameter name
   void updateAmpParameter( const string& parName = "" );
   
@@ -98,7 +98,7 @@ private:
   
   int m_rank;
   int m_numProc;
-  bool m_isMaster;
+  bool m_isLeader;
   
   map< string, complex< double >* > m_prodParMap;
   map< string, double* > m_ampParMap;

--- a/AmpTools/MinuitInterface/DerivedParameter.h
+++ b/AmpTools/MinuitInterface/DerivedParameter.h
@@ -75,7 +75,7 @@ protected:
    // DerivedParameter only updates via changes in any of the base parameters
    // upon which it depends
       void setValue( double newValue ) { Parameter::setValue( newValue ); }
-   void setError( double newError, bool notify = false ) { Parameter::setError( newError, notify ); }
+   void setError( double newError, bool notify = true ) { Parameter::setError( newError, notify ); }
    void setValueError( double newValue, double newError ) { Parameter::setValueError( newValue, newError ); }
    
 private:

--- a/AmpTools/MinuitInterface/MinuitParameterManager.cc
+++ b/AmpTools/MinuitInterface/MinuitParameterManager.cc
@@ -103,7 +103,7 @@ MinuitParameterManager::updateErrors()
       parameter->validateErrors();
       // hmm design problem?  Must have validateErrors set before we can do
       // the updateError with a notify...
-      parameter->setError( parabolicError, true );
+      parameter->setError( parabolicError );
    }
 }
 

--- a/AmpTools/MinuitInterface/Parameter.cc
+++ b/AmpTools/MinuitInterface/Parameter.cc
@@ -49,7 +49,7 @@ m_error( initialError )
 Parameter::~Parameter() {}
 
 void
-Parameter::setValue( double newValue ) {
+Parameter::setValue( double newValue, bool doNotify ) {
 
   if( m_value != newValue ){
 
@@ -59,14 +59,14 @@ Parameter::setValue( double newValue ) {
     // parameter hasn't actually changed.
     
     m_value = newValue;
-    notify();
+    if( doNotify ) notify();
   }
 }
 
 void
 Parameter::setError( double newError, bool doNotify ) {
    m_error = newError;
-   if ( doNotify ) notify();
+   if( doNotify ) notify();
 }
 
 void

--- a/AmpTools/MinuitInterface/Parameter.h
+++ b/AmpTools/MinuitInterface/Parameter.h
@@ -50,12 +50,12 @@ public:
   
   const std::string& name() const;
   
-  void setValue( double newValue );
+  void setValue( double newValue, bool doNotify = true );
   double value() const {return m_value;}
   const double* constValuePtr() const { return &m_value; }
   double* valuePtr() { return &m_value; }
   
-  virtual void setError( double newError, bool notify = false );
+  virtual void setError( double newError, bool doNotify = true );
   virtual double error() const {return m_error;}
   
   void setValueError( double newValue, double newError );

--- a/Tutorials/Dalitz/DalitzExeMPI/fitAmplitudes.cc
+++ b/Tutorials/Dalitz/DalitzExeMPI/fitAmplitudes.cc
@@ -82,10 +82,11 @@ int main( int argc, char* argv[] ){
     }
 
     cout << "LIKELIHOOD AFTER MINIMIZATION:  " << ATI.likelihood() << endl;
+
+    ATI.finalizeFit();
   }
 
-  ATI.finalizeFit();
-
+  ATI.exitMPI();
   MPI_Finalize();
 
   return 0;


### PR DESCRIPTION
This enables repeated fitting with randomized production parameters.  In order to do this the MPI version of AmpToolsInterface had to be enhanced to include both finalizeFit() and exitMPI() functions to end a fit and end a job, respectively.  This requires modifications to fitting executables that use MPI.  See the Dalitz Tutorial for an example.