### PR TITLE
suppress checking the sign of the sum of background weights on indivi…

### DIFF
--- a/AmpTools/IUAmpTools/LikelihoodCalculator.cc
+++ b/AmpTools/IUAmpTools/LikelihoodCalculator.cc
@@ -206,7 +206,7 @@ LikelihoodCalculator::normIntTerm(){
 }
 
 double
-LikelihoodCalculator::dataTerm(){
+LikelihoodCalculator::dataTerm( bool suppressError ){
   
 #ifdef VTRACE
   VT_TRACER( "LikelihoodCalculator::dataTerm" );
@@ -256,7 +256,10 @@ LikelihoodCalculator::dataTerm(){
       
       m_sumBkgWeights = m_ampVecsBkgnd.m_dSumWeights;
       
-      if( m_sumBkgWeights < 0 ){
+      // the extra boolean allows MPI jobs to suppress this check which
+      // may fail on one of the follower nodes if the background sample
+      // is sparse
+      if( m_sumBkgWeights < 0 && !suppressError ){
         cerr
         << "****************************************************************\n"
         << "* ERROR: The sum of all background weights is negative.  This  *\n"

--- a/AmpTools/IUAmpTools/LikelihoodCalculator.h
+++ b/AmpTools/IUAmpTools/LikelihoodCalculator.h
@@ -90,7 +90,7 @@ protected:
   
   // helper functions -- also useful for pulling parts of the
   // likelihood calculation in parallel implementations
-  double dataTerm();
+  double dataTerm( bool suppressError = false );
   double normIntTerm();
   
   // these are useful for MPI implementations since there are a

--- a/AmpTools/IUAmpToolsMPI/LikelihoodCalculatorMPI.cc
+++ b/AmpTools/IUAmpToolsMPI/LikelihoodCalculatorMPI.cc
@@ -184,6 +184,18 @@ LikelihoodCalculatorMPI::operator()()
   setSumBkgWeights( sumBkgWeights );
   setNumBkgEvents ( numBkgEvents  );
   setNumDataEvents( numDataEvents );
+
+  if( sumBkgWeights < 0 ){
+    cerr
+    << "****************************************************************\n"
+    << "* ERROR: The sum of all background weights is negative.  This  *\n"
+    << "*   implies a negative background in the signal region, which  *\n"
+    << "*   unphysical.  The weighted sum of the background events     *\n"
+    << "*   should represent the background contribution to the signal *\n"
+    << "*   region.                                                    *\n"
+    << "****************************************************************\n" << endl;
+    assert( false );
+  }
   
   // if we have an amplitude with a free parameter, the call to normIntTerm()
   // will trigger recomputation of NI's -- we need to put the followers in the
@@ -251,7 +263,10 @@ LikelihoodCalculatorMPI::computeLikelihood()
   
   double data[4];
   
-  data[0] = dataTerm();
+  // true flag will suppress error checking on the
+  // sum of background weights on each node -- this checking
+  // happpens on the leader node in operator()() above
+  data[0] = dataTerm( true );
   data[1] = sumBkgWeights();
   data[2] = numBkgEvents();
   data[3] = numDataEvents();


### PR DESCRIPTION
…dual MPI jobs which sometimes resulted in a failed assertion of the background sample is sparsely populated or the weights are not uniformly distributed in the sample