### PR TITLE
increase kMaxParticles to 8 for meson system decaying to 6 particles

### DIFF
--- a/AmpTools/IUAmpTools/Kinematics.h
+++ b/AmpTools/IUAmpTools/Kinematics.h
@@ -101,7 +101,7 @@ public:
    * vectors that makeup an event.
    */
   
-  enum { kMaxParticles = 7 };
+  enum { kMaxParticles = 8 };
   
   /**
    * Set the event ID.


### PR DESCRIPTION
When trying to use split_mass for gamma p -> p gamma gamma gamma gamma pi-plus pi-minus I receive the error that Assertion `m_nPart < Kinematics::kMaxParticles' failed. I believe that this is due to the hard-coded value of 7 of kMaxParticles.