### PR TITLE
Mpi v4 fix

### DIFF
--- a/AmpTools/IUAmpToolsMPI/DataReaderMPI.h
+++ b/AmpTools/IUAmpToolsMPI/DataReaderMPI.h
@@ -6,21 +6,6 @@
 #include "IUAmpTools/Kinematics.h"
 #include "IUAmpToolsMPI/MPITag.h"
 
-// starting with MPI v4 there appears to be a
-// backwards incompatible change in the name of
-// some functions
-#if MPI_VERSION > 3
-
-#define MPI_ADDRESS(A,B) MPI_Get_address(A,B)
-#define MPI_TYPE_STRUCT(A,B,C,D,E) MPI_Type_create_struct(A,B,C,D,E)
-
-#else
-
-#define MPI_ADDRESS(A,B) MPI_Address(A,B)
-#define MPI_TYPE_STRUCT(A,B,C,D,E) MPI_Type_struct(A,B,C,D,E)
-
-#endif
-
 /**
  * This is a helper struct that is used to pass kinematic data between
  * different processes using MPI.
@@ -373,39 +358,39 @@ void DataReaderMPI<T>::defineMPIType()
   MPI_Datatype type[6];
   
   MPI_Aint baseAddress;
-  MPI_ADDRESS( &kinStruct, &baseAddress );
+  MPI_Get_address( &kinStruct, &baseAddress );
   
   length[0] = 1;
-  MPI_ADDRESS( &kinStruct.nPart, &loc[0] );
+  MPI_Get_address( &kinStruct.nPart, &loc[0] );
   loc[0] -= baseAddress;
   type[0] = MPI_INT;
   
   length[1] = 1;
-  MPI_ADDRESS( &kinStruct.weight, &loc[1] );
+  MPI_Get_address( &kinStruct.weight, &loc[1] );
   loc[1] -= baseAddress;
   type[1] = MPI_FLOAT;
   
   length[2] = Kinematics::kMaxParticles;
-  MPI_ADDRESS( &kinStruct.e, &loc[2] );
+  MPI_Get_address( &kinStruct.e, &loc[2] );
   loc[2] -= baseAddress;
   type[2] = MPI_FLOAT;
   
   length[3] = Kinematics::kMaxParticles;
-  MPI_ADDRESS( &kinStruct.px, &loc[3] );
+  MPI_Get_address( &kinStruct.px, &loc[3] );
   loc[3] -= baseAddress;
   type[3] = MPI_FLOAT;
   
   length[4] = Kinematics::kMaxParticles;
-  MPI_ADDRESS( &kinStruct.py, &loc[4] );
+  MPI_Get_address( &kinStruct.py, &loc[4] );
   loc[4] -= baseAddress;
   type[4] = MPI_FLOAT;
   
   length[5] = Kinematics::kMaxParticles;
-  MPI_ADDRESS( &kinStruct.pz, &loc[5] );
+  MPI_Get_address( &kinStruct.pz, &loc[5] );
   loc[5] -= baseAddress;
   type[5] = MPI_FLOAT;
   
-  MPI_TYPE_STRUCT( 6, length, loc, type, &MPI_KinStruct );
+  MPI_Type_create_struct( 6, length, loc, type, &MPI_KinStruct );
   MPI_Type_commit( &MPI_KinStruct );
 }
 

--- a/AmpTools/IUAmpToolsMPI/DataReaderMPI.h
+++ b/AmpTools/IUAmpToolsMPI/DataReaderMPI.h
@@ -6,6 +6,21 @@
 #include "IUAmpTools/Kinematics.h"
 #include "IUAmpToolsMPI/MPITag.h"
 
+// starting with MPI v4 there appears to be a
+// backwards incompatible change in the name of
+// some functions
+#if MPI_VERSION > 3
+
+#define MPI_ADDRESS(A,B) MPI_Get_address(A,B)
+#define MPI_TYPE_STRUCT(A,B,C,D,E) MPI_Type_create_struct(A,B,C,D,E)
+
+#else
+
+#define MPI_ADDRESS(A,B) MPI_Address(A,B)
+#define MPI_TYPE_STRUCT(A,B,C,D,E) MPI_Type_struct(A,B,C,D,E)
+
+#endif
+
 /**
  * This is a helper struct that is used to pass kinematic data between
  * different processes using MPI.
@@ -358,39 +373,39 @@ void DataReaderMPI<T>::defineMPIType()
   MPI_Datatype type[6];
   
   MPI_Aint baseAddress;
-  MPI_Address( &kinStruct, &baseAddress );
+  MPI_ADDRESS( &kinStruct, &baseAddress );
   
   length[0] = 1;
-  MPI_Address( &kinStruct.nPart, &loc[0] );
+  MPI_ADDRESS( &kinStruct.nPart, &loc[0] );
   loc[0] -= baseAddress;
   type[0] = MPI_INT;
   
   length[1] = 1;
-  MPI_Address( &kinStruct.weight, &loc[1] );
+  MPI_ADDRESS( &kinStruct.weight, &loc[1] );
   loc[1] -= baseAddress;
   type[1] = MPI_FLOAT;
   
   length[2] = Kinematics::kMaxParticles;
-  MPI_Address( &kinStruct.e, &loc[2] );
+  MPI_ADDRESS( &kinStruct.e, &loc[2] );
   loc[2] -= baseAddress;
   type[2] = MPI_FLOAT;
   
   length[3] = Kinematics::kMaxParticles;
-  MPI_Address( &kinStruct.px, &loc[3] );
+  MPI_ADDRESS( &kinStruct.px, &loc[3] );
   loc[3] -= baseAddress;
   type[3] = MPI_FLOAT;
   
   length[4] = Kinematics::kMaxParticles;
-  MPI_Address( &kinStruct.py, &loc[4] );
+  MPI_ADDRESS( &kinStruct.py, &loc[4] );
   loc[4] -= baseAddress;
   type[4] = MPI_FLOAT;
   
   length[5] = Kinematics::kMaxParticles;
-  MPI_Address( &kinStruct.pz, &loc[5] );
+  MPI_ADDRESS( &kinStruct.pz, &loc[5] );
   loc[5] -= baseAddress;
   type[5] = MPI_FLOAT;
   
-  MPI_Type_struct( 6, length, loc, type, &MPI_KinStruct );
+  MPI_TYPE_STRUCT( 6, length, loc, type, &MPI_KinStruct );
   MPI_Type_commit( &MPI_KinStruct );
 }
 

--- a/AmpTools/IUAmpToolsMPI/LikelihoodCalculatorMPI.cc
+++ b/AmpTools/IUAmpToolsMPI/LikelihoodCalculatorMPI.cc
@@ -172,7 +172,7 @@ LikelihoodCalculatorMPI::operator()()
   // collect the sums
   for( int i = 1; i < m_numProc; ++i ){
     
-    MPI_Recv( &data, 4, MPI_DOUBLE, i, MPITag::kDoubleSend,
+    MPI_Recv( (double*)&data, 4, MPI_DOUBLE, i, MPITag::kDoubleSend,
              MPI_COMM_WORLD, &status );
     
     lnL           += data[0];
@@ -271,7 +271,7 @@ LikelihoodCalculatorMPI::computeLikelihood()
   data[2] = numBkgEvents();
   data[3] = numDataEvents();
   
-  MPI_Send( &data, 4, MPI_DOUBLE, 0, MPITag::kDoubleSend, MPI_COMM_WORLD );
+  MPI_Send( (double*)&data, 4, MPI_DOUBLE, 0, MPITag::kDoubleSend, MPI_COMM_WORLD );
 }
 
 void

--- a/AmpTools/IUAmpToolsMPI/LikelihoodManagerMPI.cc
+++ b/AmpTools/IUAmpToolsMPI/LikelihoodManagerMPI.cc
@@ -111,7 +111,7 @@ LikelihoodManagerMPI::deliverLikelihood()
         assert( false );
     }
     
-    MPI_Recv( &cmnd, 2, MPI_INT, 0, MPITag::kIntSend, 
+    MPI_Recv( (int*)&cmnd, 2, MPI_INT, 0, MPITag::kIntSend,
              MPI_COMM_WORLD, &status );
   }
 


### PR DESCRIPTION
This removes deprecated MPI function calls.  Also adds a cast to eliminate a compiler warning in clang.