### PR TITLE
fix bug that resulted incorrect four-vectors being returned by getEvent

### DIFF
--- a/AmpTools/IUAmpTools/AmpVecs.cc
+++ b/AmpTools/IUAmpTools/AmpVecs.cc
@@ -177,37 +177,14 @@ AmpVecs::loadEvent( const Kinematics* pKinematics, unsigned long long iEvent,
   
   // check to be sure we won't exceed the bounds of the array
   assert( iEvent < m_iNEvents );
-  
-  // for cpu calculations, fill the m_pdData array in this order:
-  //    e(p1,ev1), px(p1,ev1), py(p1,ev1), pz(p1,ev1),
-  //    e(p2,ev1), px(p2,ev1), ...,
-  //    e(p1,ev2), px(p1,ev2), ...
-  // 
-  // for gpu calculations, fill the m_pdData array in this order:
-  //     e(p1,ev1),  e(p1,ev2),  e(p1,ev3), ...,
-  //    px(p1,ev1), px(p1,ev2), ...,
-  //     e(p2,ev1),  e(p2,ev2). ...
-  //
-  // where pn is particle n and evn is event n  
-  
-  //#ifndef GPU_ACCELERATION
-  
+    
   for (int iParticle = 0; iParticle < m_iNParticles; iParticle++){
     m_pdData[4*iEvent*m_iNParticles+4*iParticle+0]=pKinematics->particle(iParticle).E();
     m_pdData[4*iEvent*m_iNParticles+4*iParticle+1]=pKinematics->particle(iParticle).Px();
     m_pdData[4*iEvent*m_iNParticles+4*iParticle+2]=pKinematics->particle(iParticle).Py();
     m_pdData[4*iEvent*m_iNParticles+4*iParticle+3]=pKinematics->particle(iParticle).Pz();
   }
-  /*
-#else
-  for (int iParticle = 0; iParticle < m_iNParticles; iParticle++){
-    m_pdData[(4*iParticle+0)*m_iNEvents+iEvent] = pKinematics->particle(iParticle).E();
-    m_pdData[(4*iParticle+1)*m_iNEvents+iEvent] = pKinematics->particle(iParticle).Px();
-    m_pdData[(4*iParticle+2)*m_iNEvents+iEvent] = pKinematics->particle(iParticle).Py();
-    m_pdData[(4*iParticle+3)*m_iNEvents+iEvent] = pKinematics->particle(iParticle).Pz();
-  }
-#endif
-*/
+
   m_pdWeights[iEvent] = pKinematics->weight();
   
   m_termsValid = false;
@@ -368,21 +345,9 @@ AmpVecs::getEvent( int iEvent ){
   
   for( int iPart = 0; iPart < m_iNParticles; ++iPart ){
     
-    // packing is different for GPU and CPU
-    
-#ifndef GPU_ACCELERATION
-    
     int i = iEvent*4*m_iNParticles + 4*iPart;
     particleList.push_back( TLorentzVector( m_pdData[i+1], m_pdData[i+2],
-                                             m_pdData[i+3], m_pdData[i] ) );
-#else
-    
-    particleList.
-    push_back( TLorentzVector( m_pdData[(4*iPart+1)*m_iNEvents+iEvent],
-                                m_pdData[(4*iPart+2)*m_iNEvents+iEvent],
-                                m_pdData[(4*iPart+3)*m_iNEvents+iEvent],
-                                m_pdData[(4*iPart+0)*m_iNEvents+iEvent] ) );
-#endif // GPU_ACCELERATION
+                                            m_pdData[i+3], m_pdData[i] ) );
   }
   
   return new Kinematics( particleList, m_pdWeights[iEvent] );

--- a/AmpTools/README
+++ b/AmpTools/README
@@ -83,7 +83,7 @@ the square root of the intensity computed from the parameters and the kinematics
 
 RELEASE NOTES:
 
-v0.12.? (???):
+v0.13.0 (11-Feb-2022):
 
 This includes an overhaul of the Makefile system.  All functionality remains
 very similar, but now the entire tree can be built from make from the top
@@ -94,6 +94,12 @@ This version includes support for OpenMPI-4 which removed some deprecated
 function calls that were still being used in the MPI code.  These calls have
 been updated and should not cause any compatibility issues -- they were
 deprecated in MPI v2.
+
+A bug was fixed that resulted in incorrect four-vectors to be read from
+memory when using the AmpToolsInterface to get the Kinematics object for
+a single event.  This is not typically done in fitting (where GPU
+acceleration is often used) so many users may not have noticed this
+bug.
 
 v0.12.2 (20-Sep-2021):
 


### PR DESCRIPTION
This is very unlikely to affect the results of any fits.  However, it will fix MC generation and plotting code that does GPU calculations of amplitudes and then retrieves the four-vectors for example to write after accept/reject.