### PR TITLE
Expand NI caching to hold generated MC also

### DIFF
--- a/AmpTools/IUAmpTools/AmpVecs.h
+++ b/AmpTools/IUAmpTools/AmpVecs.h
@@ -70,14 +70,14 @@ struct AmpVecs
   /**
    * An integer that stores the number of events.
    */
-  unsigned long long m_iNEvents;
+  unsigned long m_iNEvents;
   
   /**
    * An integer that stores the true number of events.  For GPU calculations
    * it is necessary to pad iNEvents up to the next power of 2.  This integer
    * stores the actual number of unique events.
    */
-  unsigned long long m_iNTrueEvents;
+  unsigned long m_iNTrueEvents;
   
   /**
    * A double that stores the absolute value of the sum of the weights.  (For

--- a/AmpTools/IUAmpTools/NormIntInterface.h
+++ b/AmpTools/IUAmpTools/NormIntInterface.h
@@ -64,7 +64,7 @@ public:
   istream& loadNormIntCache( istream& in );
   void operator+=( const NormIntInterface& nii );
 
-  int numGenEvents() const { return m_nGenEvents; }
+  unsigned long int numGenEvents() const { return m_nGenEvents; }
   double numAccEvents() const { return m_sumAccWeights; }
   
   // does this interface have the ability to recalculate integrals?
@@ -90,7 +90,7 @@ public:
   const GDouble* ampIntMatrix() const  { return m_ampIntCache;  }
   const GDouble* normIntMatrix() const { return m_normIntCache; }
   
-  void setGenEvents( int events ) { m_nGenEvents = events; }
+  void setGenEvents( unsigned long int events ) { m_nGenEvents = events; }
   void setAccEvents( double sumWeights ) { m_sumAccWeights = sumWeights; }
   
 protected:
@@ -112,8 +112,8 @@ private:
   DataReader* m_accMCReader;
   DataReader* m_genMCReader;
   
-  int m_nGenEvents;
-  mutable double m_sumAccWeights; // mutable enables lazy evaluation
+  unsigned long int m_nGenEvents;
+  double m_sumAccWeights;
   
   vector< string > m_termNames;
   map< string, int > m_termIndex;
@@ -121,9 +121,10 @@ private:
   mutable bool m_emptyNormIntCache;
   mutable bool m_emptyAmpIntCache;
   
-  // needed to cache accepted MC data for NI recalculation
-  mutable AmpVecs m_mcVecs;
-
+  // caches for MC
+  mutable AmpVecs m_accMCVecs;
+  mutable AmpVecs m_genMCVecs;
+  
   int m_cacheSize;
 
   mutable GDouble* m_normIntCache;

--- a/AmpTools/IUAmpToolsMPI/MPITag.h
+++ b/AmpTools/IUAmpToolsMPI/MPITag.h
@@ -56,6 +56,7 @@ class MPITag {
    */
   
   enum { kIntSend = 1,
+    kLongIntSend,
     kDoubleSend,
     kCharSend,
     kDataSend,

--- a/AmpTools/IUAmpToolsMPI/NormIntInterfaceMPI.cc
+++ b/AmpTools/IUAmpToolsMPI/NormIntInterfaceMPI.cc
@@ -95,31 +95,32 @@ NormIntInterfaceMPI::setupMPI()
   
   m_isLeader = ( m_rank == 0 );
   
-  int totalGenEvents = 0;
+  // this is unsigned elsewhere, but MPI
+  unsigned long int totalGenEvents = 0;
   double totalAccWeights = 0;
     
   if( m_isLeader ){
     
     for( int i = 1; i < m_numProc; ++i ){
       
-      int thisEvents;
+      unsigned long int thisEvents;
       double thisWeights;
 
       // trigger sending of events from followers -- data is irrelevant
-      MPI_Send( &thisEvents, 1, MPI_INT, i, MPITag::kAcknowledge,
+      MPI_Send( &thisEvents, 1, MPI_UNSIGNED_LONG, i, MPITag::kAcknowledge,
                MPI_COMM_WORLD );
       
       // now receive actual data
-      MPI_Recv( &thisEvents, 1, MPI_INT, i, MPITag::kIntSend,
+      MPI_Recv( &thisEvents, 1, MPI_UNSIGNED_LONG, i, MPITag::kLongIntSend,
                MPI_COMM_WORLD, &status );
       totalGenEvents += thisEvents;
       
-      MPI_Recv( &thisWeights, 1, MPI_DOUBLE, i, MPITag::kIntSend,
+      MPI_Recv( &thisWeights, 1, MPI_DOUBLE, i, MPITag::kDoubleSend,
                MPI_COMM_WORLD, &status );
       totalAccWeights += thisWeights;
       
       // send acknowledgment 
-      MPI_Send( &thisEvents, 1, MPI_INT, i, MPITag::kAcknowledge,
+      MPI_Send( &thisEvents, 1, MPI_UNSIGNED_LONG, i, MPITag::kAcknowledge,
                MPI_COMM_WORLD );
     }
     
@@ -128,7 +129,7 @@ NormIntInterfaceMPI::setupMPI()
   }
   else{
     
-    int thisEvents;
+    unsigned long int thisEvents;
     double thisWeights;
 
     // if we are not the leader, send generated and accepted events
@@ -139,16 +140,16 @@ NormIntInterfaceMPI::setupMPI()
     // to signal that it is ready to accept numbers of events
 
     // data is irrelevant for this receive
-    MPI_Recv( &thisEvents, 1, MPI_INT, 0, MPITag::kAcknowledge, MPI_COMM_WORLD,
+    MPI_Recv( &thisEvents, 1, MPI_UNSIGNED_LONG, 0, MPITag::kAcknowledge, MPI_COMM_WORLD,
               &status );
 
     thisEvents = numGenEvents();
-    MPI_Send( &thisEvents, 1, MPI_INT, 0, MPITag::kIntSend, MPI_COMM_WORLD );
+    MPI_Send( &thisEvents, 1, MPI_UNSIGNED_LONG, 0, MPITag::kLongIntSend, MPI_COMM_WORLD );
     
     thisWeights = numAccEvents();
-    MPI_Send( &thisWeights, 1, MPI_DOUBLE, 0, MPITag::kIntSend, MPI_COMM_WORLD );
+    MPI_Send( &thisWeights, 1, MPI_DOUBLE, 0, MPITag::kDoubleSend, MPI_COMM_WORLD );
     
-    MPI_Recv( &thisEvents, 1, MPI_INT, 0, MPITag::kAcknowledge, MPI_COMM_WORLD,
+    MPI_Recv( &thisEvents, 1, MPI_UNSIGNED_LONG, 0, MPITag::kAcknowledge, MPI_COMM_WORLD,
              &status );
   }
 }


### PR DESCRIPTION
This change modifies the behavior of the Normalization Integral interface to load and cache the generated MC at the beginning and throughout the fit.  This resolves a problem where when doing the repeated fits with randomized start parameters the MC is repeatedly loaded and unloaded.  It is suspected that this could lead to memory fragmentation on the GPU and ultimately an "out of memory" error.

This also repairs a bug noticed:  when running MPI jobs the sum of accepted weights was not correct.  This would cause crashing with subsequent plotting code.  That is fixed with this PR.