### PR TITLE
Scorep profiling

### DIFF
--- a/AmpPlotter/Makefile
+++ b/AmpPlotter/Makefile
@@ -9,11 +9,11 @@ include $(AMPTOOLS_HOME)/Makefile.settings
 # Most things below here probably don't need to be changed
 #
 # (expert option for profile and tracing)
-# to build code instrumented for Vampir Trace use VTRACE=1
+# to build code instrumented for Vampir Trace use SCOREP=1
 
-ifdef VTRACE
-CXX := vtcxx -vt:inst manual
-CXX_FLAGS += -DVTRACE
+ifdef SCOREP
+CXX := scorep-g++ --user
+CXX_FLAGS += -DSCOREP_USER_ENABLE
 endif
 
 INC_DIR :=  -I.. -I$(shell root-config --incdir) -I$(AMPTOOLS)

--- a/AmpTools/GPUManager/GPUManager.cc
+++ b/AmpTools/GPUManager/GPUManager.cc
@@ -50,8 +50,8 @@
 #include "GPUManager/GPUKernel.h"
 #include "GPUManager/GPUManager.h"
 
-#ifdef VTRACE
-#include "vt_user.h"
+#ifdef SCOREP
+#include <scorep/SCOREP_User.h>
 #endif
 
 bool GPUManager::m_cudaDisplay = false;
@@ -226,10 +226,10 @@ GPUManager::init( const AmpVecs& a, bool use4Vectors )
 void
 GPUManager::copyDataToGPU( const AmpVecs& a, bool use4Vectors )
 {  
-
-#ifdef VTRACE
-  VT_TRACER( "GPUManager::copyDataToGPU" );
-#endif
+  #ifdef SCOREP
+  SCOREP_USER_REGION_DEFINE( scorep_copyDataToGPU )                                                                                    
+  SCOREP_USER_REGION_BEGIN( scorep_copyDataToGPU, "scorep_copyDataToGPU", SCOREP_USER_REGION_TYPE_COMMON )
+  #endif
   
   // copy the weights to the GPU
   gpuErrChk( cudaMemcpy( m_pfDevWeights, a.m_pdWeights,
@@ -283,15 +283,18 @@ GPUManager::copyDataToGPU( const AmpVecs& a, bool use4Vectors )
 
     delete tmpStorage;
   }
+  #ifdef SCOREP
+  SCOREP_USER_REGION_END( scorep_copyDataToGPU )
+  #endif
 }
 
 void
 GPUManager::copyUserVarsToGPU( const AmpVecs& a )
 {
-  
-#ifdef VTRACE
-  VT_TRACER( "GPUManager::copyUserVarsToGPU" );
-#endif
+  #ifdef SCOREP
+  SCOREP_USER_REGION_DEFINE( scorep_copyUserVarsToGPU )                                                                                    
+  SCOREP_USER_REGION_BEGIN( scorep_copyUserVarsToGPU, "scorep_copyUserVarsToGPU", SCOREP_USER_REGION_TYPE_COMMON )                           
+  #endif
   
   // make sure AmpVecs has been loaded with data
   assert( a.m_pdUserVars );
@@ -300,16 +303,19 @@ GPUManager::copyUserVarsToGPU( const AmpVecs& a )
   gpuErrChk( cudaMemcpy( m_pfDevUserVars, a.m_pdUserVars,
                         m_iNUserVars * m_iEventArrSize,
                         cudaMemcpyHostToDevice ) );
+  #ifdef SCOREP
+  SCOREP_USER_REGION_END( scorep_copyUserVarsToGPU ) 
+  #endif
 }
 
 
 void
 GPUManager::copyAmpsFromGPU( AmpVecs& a )
 {
-
-#ifdef VTRACE
-  VT_TRACER( "GPUManager::copyAmpsToGPU" );
-#endif
+  #ifdef SCOREP
+  SCOREP_USER_REGION_DEFINE( scorep_copyAmpsFromGPU )                                                                                    
+  SCOREP_USER_REGION_BEGIN( scorep_copyAmpsFromGPU, "scorep_copyAmpsFromGPU", SCOREP_USER_REGION_TYPE_COMMON )                           
+  #endif
   
   // this array is not allocated by default on GPU enabled code
   // to save CPU memory -- the user must allocate it explicitly
@@ -322,6 +328,9 @@ GPUManager::copyAmpsFromGPU( AmpVecs& a )
   gpuErrChk( cudaMemcpy( a.m_pdAmpFactors, m_pcDevCalcAmp,
                          a.m_maxFactPerEvent * m_iEventArrSize,
                          cudaMemcpyDeviceToHost ) );
+  #ifdef SCOREP
+  SCOREP_USER_REGION_END( scorep_copyAmpsFromGPU )
+  #endif
 }
 
 void 
@@ -329,9 +338,10 @@ GPUManager::calcAmplitudeAll( const Amplitude* amp, unsigned long long offset,
                               const vector< vector< int > >* pvPermutations,
                               unsigned long long iUserVarsOffset )
 {
-#ifdef VTRACE
-  VT_TRACER( "GPUManager::calcAmplitudeAll" );
-#endif
+  #ifdef SCOREP
+  SCOREP_USER_REGION_DEFINE( scorep_calcAmplitudeAll_gpuMgr )                                                                                    
+  SCOREP_USER_REGION_BEGIN( scorep_calcAmplitudeAll_gpuMgr, "scorep_calcAmplitudeAll_gpuMgr", SCOREP_USER_REGION_TYPE_COMMON )                           
+  #endif
   
   dim3 dimBlock( m_iDimThreadX, m_iDimThreadY );
   dim3 dimGrid( m_iDimGridX, m_iDimGridY );
@@ -376,14 +386,17 @@ GPUManager::calcAmplitudeAll( const Amplitude* amp, unsigned long long offset,
     permOffset += 2 * m_iNEvents;
     udLocalOffset += amp->numUserVars() * m_iNEvents;
   }    
+  #ifdef SCOREP
+  SCOREP_USER_REGION_END( scorep_calcAmplitudeAll_gpuMgr )
+  #endif
 }
 
 void
 GPUManager::assembleTerms( int iAmpInd, int nFact, int nPerm ){
-  
-#ifdef VTRACE
-  VT_TRACER( "GPUManager::assembleTerms" );
-#endif
+  #ifdef SCOREP
+  SCOREP_USER_REGION_DEFINE( scorep_assembleTerms )                                                                                    
+  SCOREP_USER_REGION_BEGIN( scorep_assembleTerms, "scorep_assembleTerms", SCOREP_USER_REGION_TYPE_COMMON )                           
+  #endif
 
   dim3 dimBlock( m_iDimThreadX, m_iDimThreadY );
   dim3 dimGrid( m_iDimGridX, m_iDimGridY );
@@ -393,16 +406,19 @@ GPUManager::assembleTerms( int iAmpInd, int nFact, int nPerm ){
   
   GPU_ExecFactPermKernel( dimGrid, dimBlock, &(m_pfDevAmps[2*m_iNEvents*iAmpInd]),
                           m_pcDevCalcAmp, nFact, nPerm, m_iNEvents );
+  #ifdef SCOREP
+  SCOREP_USER_REGION_END( scorep_assembleTerms ) 
+  #endif
 }
 
 double
 GPUManager::calcSumLogIntensity( const vector< complex< double > >& prodCoef,
                                 const vector< vector< bool > >& cohMtx )
 {
-
-#ifdef VTRACE
-  VT_TRACER( "GPUManager::calcSumLogIntensity" );
-#endif
+  #ifdef SCOREP
+  SCOREP_USER_REGION_DEFINE( scorep_calcSumLogIntensity_gpuMgr )                                                                                    
+  SCOREP_USER_REGION_BEGIN( scorep_calcSumLogIntensity_gpuMgr, "scorep_calcSumLogIntensity_gpuMgr", SCOREP_USER_REGION_TYPE_COMMON )                           
+  #endif
 
   unsigned int i,j;
   
@@ -476,15 +492,18 @@ GPUManager::calcSumLogIntensity( const vector< complex< double > >& prodCoef,
     for(i=0; i<m_iNBlocks; i++)
       dGPUResult += m_pfRes[i];
   }
+  #ifdef SCOREP
+  SCOREP_USER_REGION_END( scorep_calcSumLogIntensity_gpuMgr )
+  #endif
   return dGPUResult;
 }
 
 void
 GPUManager::calcIntegral( GDouble* result, int iAmp, int jAmp, int iNGenEvents ){
-  
-#ifdef VTRACE
-  VT_TRACER( "GPUManager::calcIntegral" );
-#endif
+  #ifdef SCOREP
+  SCOREP_USER_REGION_DEFINE( scorep_calcIntegral )                                                                                    
+  SCOREP_USER_REGION_BEGIN( scorep_calcIntegral, "scorep_calcIntegral", SCOREP_USER_REGION_TYPE_COMMON )                           
+  #endif
 
   dim3 dimBlock( m_iDimThreadX, m_iDimThreadY );
   dim3 dimGrid( m_iDimGridX, m_iDimGridY );
@@ -561,6 +580,9 @@ GPUManager::calcIntegral( GDouble* result, int iAmp, int jAmp, int iNGenEvents )
 
     result[1] /= static_cast< GDouble >( iNGenEvents );
   }
+  #ifdef SCOREP
+  SCOREP_USER_REGION_END( scorep_calcIntegral ) 
+  #endif
 }
 
 

--- a/AmpTools/GPUManager/GPUManager.cc
+++ b/AmpTools/GPUManager/GPUManager.cc
@@ -227,8 +227,8 @@ void
 GPUManager::copyDataToGPU( const AmpVecs& a, bool use4Vectors )
 {  
   #ifdef SCOREP
-  SCOREP_USER_REGION_DEFINE( scorep_copyDataToGPU )                                                                                    
-  SCOREP_USER_REGION_BEGIN( scorep_copyDataToGPU, "scorep_copyDataToGPU", SCOREP_USER_REGION_TYPE_COMMON )
+  SCOREP_USER_REGION_DEFINE( copyDataToGPU )                                                                                    
+  SCOREP_USER_REGION_BEGIN( copyDataToGPU, "copyDataToGPU", SCOREP_USER_REGION_TYPE_COMMON )
   #endif
   
   // copy the weights to the GPU
@@ -284,7 +284,7 @@ GPUManager::copyDataToGPU( const AmpVecs& a, bool use4Vectors )
     delete tmpStorage;
   }
   #ifdef SCOREP
-  SCOREP_USER_REGION_END( scorep_copyDataToGPU )
+  SCOREP_USER_REGION_END( copyDataToGPU )
   #endif
 }
 
@@ -292,8 +292,8 @@ void
 GPUManager::copyUserVarsToGPU( const AmpVecs& a )
 {
   #ifdef SCOREP
-  SCOREP_USER_REGION_DEFINE( scorep_copyUserVarsToGPU )                                                                                    
-  SCOREP_USER_REGION_BEGIN( scorep_copyUserVarsToGPU, "scorep_copyUserVarsToGPU", SCOREP_USER_REGION_TYPE_COMMON )                           
+  SCOREP_USER_REGION_DEFINE( copyUserVarsToGPU )                                                                                    
+  SCOREP_USER_REGION_BEGIN( copyUserVarsToGPU, "copyUserVarsToGPU", SCOREP_USER_REGION_TYPE_COMMON )                           
   #endif
   
   // make sure AmpVecs has been loaded with data
@@ -304,7 +304,7 @@ GPUManager::copyUserVarsToGPU( const AmpVecs& a )
                         m_iNUserVars * m_iEventArrSize,
                         cudaMemcpyHostToDevice ) );
   #ifdef SCOREP
-  SCOREP_USER_REGION_END( scorep_copyUserVarsToGPU ) 
+  SCOREP_USER_REGION_END( copyUserVarsToGPU ) 
   #endif
 }
 
@@ -313,8 +313,8 @@ void
 GPUManager::copyAmpsFromGPU( AmpVecs& a )
 {
   #ifdef SCOREP
-  SCOREP_USER_REGION_DEFINE( scorep_copyAmpsFromGPU )                                                                                    
-  SCOREP_USER_REGION_BEGIN( scorep_copyAmpsFromGPU, "scorep_copyAmpsFromGPU", SCOREP_USER_REGION_TYPE_COMMON )                           
+  SCOREP_USER_REGION_DEFINE( copyAmpsFromGPU )                                                                                    
+  SCOREP_USER_REGION_BEGIN( copyAmpsFromGPU, "copyAmpsFromGPU", SCOREP_USER_REGION_TYPE_COMMON )                           
   #endif
   
   // this array is not allocated by default on GPU enabled code
@@ -329,7 +329,7 @@ GPUManager::copyAmpsFromGPU( AmpVecs& a )
                          a.m_maxFactPerEvent * m_iEventArrSize,
                          cudaMemcpyDeviceToHost ) );
   #ifdef SCOREP
-  SCOREP_USER_REGION_END( scorep_copyAmpsFromGPU )
+  SCOREP_USER_REGION_END( copyAmpsFromGPU )
   #endif
 }
 
@@ -339,8 +339,8 @@ GPUManager::calcAmplitudeAll( const Amplitude* amp, unsigned long long offset,
                               unsigned long long iUserVarsOffset )
 {
   #ifdef SCOREP
-  SCOREP_USER_REGION_DEFINE( scorep_calcAmplitudeAll_gpuMgr )                                                                                    
-  SCOREP_USER_REGION_BEGIN( scorep_calcAmplitudeAll_gpuMgr, "scorep_calcAmplitudeAll_gpuMgr", SCOREP_USER_REGION_TYPE_COMMON )                           
+  SCOREP_USER_REGION_DEFINE( calcAmplitudeAll_gpuMgr )                                                                                    
+  SCOREP_USER_REGION_BEGIN( calcAmplitudeAll_gpuMgr, "calcAmplitudeAll_gpuMgr", SCOREP_USER_REGION_TYPE_COMMON )                           
   #endif
   
   dim3 dimBlock( m_iDimThreadX, m_iDimThreadY );
@@ -387,15 +387,15 @@ GPUManager::calcAmplitudeAll( const Amplitude* amp, unsigned long long offset,
     udLocalOffset += amp->numUserVars() * m_iNEvents;
   }    
   #ifdef SCOREP
-  SCOREP_USER_REGION_END( scorep_calcAmplitudeAll_gpuMgr )
+  SCOREP_USER_REGION_END( calcAmplitudeAll_gpuMgr )
   #endif
 }
 
 void
 GPUManager::assembleTerms( int iAmpInd, int nFact, int nPerm ){
   #ifdef SCOREP
-  SCOREP_USER_REGION_DEFINE( scorep_assembleTerms )                                                                                    
-  SCOREP_USER_REGION_BEGIN( scorep_assembleTerms, "scorep_assembleTerms", SCOREP_USER_REGION_TYPE_COMMON )                           
+  SCOREP_USER_REGION_DEFINE( assembleTerms )                                                                                    
+  SCOREP_USER_REGION_BEGIN( assembleTerms, "assembleTerms", SCOREP_USER_REGION_TYPE_COMMON )                           
   #endif
 
   dim3 dimBlock( m_iDimThreadX, m_iDimThreadY );
@@ -407,7 +407,7 @@ GPUManager::assembleTerms( int iAmpInd, int nFact, int nPerm ){
   GPU_ExecFactPermKernel( dimGrid, dimBlock, &(m_pfDevAmps[2*m_iNEvents*iAmpInd]),
                           m_pcDevCalcAmp, nFact, nPerm, m_iNEvents );
   #ifdef SCOREP
-  SCOREP_USER_REGION_END( scorep_assembleTerms ) 
+  SCOREP_USER_REGION_END( assembleTerms ) 
   #endif
 }
 
@@ -416,8 +416,8 @@ GPUManager::calcSumLogIntensity( const vector< complex< double > >& prodCoef,
                                 const vector< vector< bool > >& cohMtx )
 {
   #ifdef SCOREP
-  SCOREP_USER_REGION_DEFINE( scorep_calcSumLogIntensity_gpuMgr )                                                                                    
-  SCOREP_USER_REGION_BEGIN( scorep_calcSumLogIntensity_gpuMgr, "scorep_calcSumLogIntensity_gpuMgr", SCOREP_USER_REGION_TYPE_COMMON )                           
+  SCOREP_USER_REGION_DEFINE( calcSumLogIntensity_gpuMgr )                                                                                    
+  SCOREP_USER_REGION_BEGIN( calcSumLogIntensity_gpuMgr, "calcSumLogIntensity_gpuMgr", SCOREP_USER_REGION_TYPE_COMMON )                           
   #endif
 
   unsigned int i,j;
@@ -493,7 +493,7 @@ GPUManager::calcSumLogIntensity( const vector< complex< double > >& prodCoef,
       dGPUResult += m_pfRes[i];
   }
   #ifdef SCOREP
-  SCOREP_USER_REGION_END( scorep_calcSumLogIntensity_gpuMgr )
+  SCOREP_USER_REGION_END( calcSumLogIntensity_gpuMgr )
   #endif
   return dGPUResult;
 }
@@ -501,8 +501,8 @@ GPUManager::calcSumLogIntensity( const vector< complex< double > >& prodCoef,
 void
 GPUManager::calcIntegral( GDouble* result, int iAmp, int jAmp, int iNGenEvents ){
   #ifdef SCOREP
-  SCOREP_USER_REGION_DEFINE( scorep_calcIntegral )                                                                                    
-  SCOREP_USER_REGION_BEGIN( scorep_calcIntegral, "scorep_calcIntegral", SCOREP_USER_REGION_TYPE_COMMON )                           
+  SCOREP_USER_REGION_DEFINE( calcIntegral )                                                                                    
+  SCOREP_USER_REGION_BEGIN( calcIntegral, "calcIntegral", SCOREP_USER_REGION_TYPE_COMMON )                           
   #endif
 
   dim3 dimBlock( m_iDimThreadX, m_iDimThreadY );
@@ -581,7 +581,7 @@ GPUManager::calcIntegral( GDouble* result, int iAmp, int jAmp, int iNGenEvents )
     result[1] /= static_cast< GDouble >( iNGenEvents );
   }
   #ifdef SCOREP
-  SCOREP_USER_REGION_END( scorep_calcIntegral ) 
+  SCOREP_USER_REGION_END( calcIntegral ) 
   #endif
 }
 

--- a/AmpTools/IUAmpTools/Amplitude.cc
+++ b/AmpTools/IUAmpTools/Amplitude.cc
@@ -44,8 +44,8 @@
 #include "IUAmpTools/AmpParameter.h"
 #include "IUAmpTools/Kinematics.h"
 
-#ifdef VTRACE
-#include "vt_user.h"
+#ifdef SCOREP
+#include <scorep/SCOREP_User.h>
 #endif
 
 string
@@ -71,11 +71,11 @@ Amplitude::calcUserVarsAll( GDouble* pdData, GDouble* pdUserVars, int iNEvents,
                             const vector< vector< int > >* pvPermutations ) const
 {
   
-#ifdef VTRACE
-  string info = name();
-  info += "::calcUserVarsAll";
-  VT_TRACER( info.c_str() );
+#ifdef SCOREP
+SCOREP_USER_REGION_DEFINE( scorep_calcUserVarsAll )
 #endif
+
+
   
 //  cout << "Caculating user data for " << name() << endl;
   
@@ -84,6 +84,10 @@ Amplitude::calcUserVarsAll( GDouble* pdData, GDouble* pdUserVars, int iNEvents,
   // exit immediately if there is nothing to compute
   if( !numVars ) return;
   
+#ifdef SCOREP
+SCOREP_USER_REGION_BEGIN( scorep_calcUserVarsAll, "scorep_calcUserVarsAll", SCOREP_USER_REGION_TYPE_COMMON )
+#endif
+
   int iPermutation, iNPermutations = pvPermutations->size();
   assert( iNPermutations );
   
@@ -116,6 +120,10 @@ Amplitude::calcUserVarsAll( GDouble* pdData, GDouble* pdUserVars, int iNEvents,
     }
   }
   
+#ifdef SCOREP
+SCOREP_USER_REGION_END( scorep_calcUserVarsAll )
+#endif
+  
   delete[] pKin;
 }
 
@@ -124,13 +132,12 @@ Amplitude::calcAmplitudeAll( GDouble* pdData, GDouble* pdAmps, int iNEvents,
                             const vector< vector< int > >* pvPermutations,
                              GDouble* pdUserVars ) const
 {
-  
-#ifdef VTRACE
-  string info = name();
-  info += "::calcAmplitudeAll";
-  VT_TRACER( info.c_str() );
-#endif
 
+#ifdef SCOREP
+SCOREP_USER_REGION_DEFINE( scorep_calcAmplitudeAll )
+SCOREP_USER_REGION_BEGIN( scorep_calcAmplitudeAll, "scorep_calcAmplitudeAll", SCOREP_USER_REGION_TYPE_COMMON )
+#endif
+  
   complex< GDouble > cRes;
   
   unsigned int numVars = numUserVars();
@@ -176,6 +183,10 @@ Amplitude::calcAmplitudeAll( GDouble* pdData, GDouble* pdAmps, int iNEvents,
       pdAmps[2*iNEvents*iPermutation+2*iEvent+1] = cRes.imag();
     }
   }
+
+#ifdef SCOREP
+SCOREP_USER_REGION_END( scorep_calcAmplitudeAll )
+#endif
   
   delete[] pKin;
 }
@@ -243,10 +254,9 @@ Amplitude::calcAmplitude( const Kinematics* pKin,
                           const vector< int >& permutation,
                           GDouble* userVars ) const {
 
-#ifdef VTRACE
-  string info = name();
-  info += "::calcAmplitude";
-  VT_TRACER( info.c_str() );
+#ifdef SCOREP
+SCOREP_USER_REGION_DEFINE( scorep_calcAmplitude )
+SCOREP_USER_REGION_BEGIN( scorep_calcAmplitude, "scorep_calcAmplitude", SCOREP_USER_REGION_TYPE_COMMON )
 #endif
 
   vector<TLorentzVector> particleList = pKin->particleList();
@@ -280,6 +290,11 @@ Amplitude::calcAmplitude( const Kinematics* pKin,
   for (int i = 0; i < particleList.size(); i++){
     delete[] pData[i];
   }
+
+#ifdef SCOREP
+SCOREP_USER_REGION_END( scorep_calcAmplitude )
+#endif
+
   delete[] pData;
   
   return value;
@@ -291,14 +306,17 @@ Amplitude::calcAmplitude( const Kinematics* pKin,
 void
 Amplitude::calcAmplitudeGPU( dim3 dimGrid, dim3 dimBlock, GPU_AMP_PROTO,
                             const vector< int >& perm ) const {
-#ifdef VTRACE
-  string info = name();
-  info += "::calcAmplitudeGPU";
-  VT_TRACER( info.c_str() );
+#ifdef SCOREP
+  SCOREP_USER_REGION_DEFINE( scorep_calcAmplitudeGPU )
+  SCOREP_USER_REGION_BEGIN( scorep_calcAmplitudeGPU, "calcAmplitudeGPU", SCOREP_USER_REGION_TYPE_COMMON )
 #endif
 
-  m_currentPermutation = perm;
-  launchGPUKernel( dimGrid, dimBlock, GPU_AMP_ARGS );
+  	m_currentPermutation = perm;
+	launchGPUKernel( dimGrid, dimBlock, GPU_AMP_ARGS );
+  
+#ifdef SCOREP
+  SCOREP_USER_REGION_END( scorep_calcAmplitudeGPU )
+#endif
 }
 #endif
 
@@ -369,12 +387,9 @@ Amplitude::setParValue( const string& name, double val ) const {
 bool
 Amplitude::updatePar( const string& name ) const {
   
-#ifdef VTRACE
-  string info = (*this).name();
-  info += "::updatePar [";
-  info += name.c_str();
-  info += "]";
-  VT_TRACER( info.c_str() );
+#ifdef SCOREP
+SCOREP_USER_REGION_DEFINE( scorep_updatePar )
+SCOREP_USER_REGION_BEGIN( scorep_updatePar, "scorep_updatePar", SCOREP_USER_REGION_TYPE_COMMON )
 #endif
 
   
@@ -397,6 +412,9 @@ Amplitude::updatePar( const string& name ) const {
     }
   }
   
+#ifdef SCOREP
+SCOREP_USER_REGION_END( scorep_updatePar )
+#endif
   return foundPar;
 }
 

--- a/AmpTools/IUAmpTools/Amplitude.cc
+++ b/AmpTools/IUAmpTools/Amplitude.cc
@@ -72,7 +72,7 @@ Amplitude::calcUserVarsAll( GDouble* pdData, GDouble* pdUserVars, int iNEvents,
 {
   
 #ifdef SCOREP
-SCOREP_USER_REGION_DEFINE( scorep_calcUserVarsAll )
+SCOREP_USER_REGION_DEFINE( calcUserVarsAll )
 #endif
 
 
@@ -85,7 +85,7 @@ SCOREP_USER_REGION_DEFINE( scorep_calcUserVarsAll )
   if( !numVars ) return;
   
 #ifdef SCOREP
-SCOREP_USER_REGION_BEGIN( scorep_calcUserVarsAll, "scorep_calcUserVarsAll", SCOREP_USER_REGION_TYPE_COMMON )
+SCOREP_USER_REGION_BEGIN( calcUserVarsAll, "calcUserVarsAll", SCOREP_USER_REGION_TYPE_COMMON )
 #endif
 
   int iPermutation, iNPermutations = pvPermutations->size();
@@ -121,7 +121,7 @@ SCOREP_USER_REGION_BEGIN( scorep_calcUserVarsAll, "scorep_calcUserVarsAll", SCOR
   }
   
 #ifdef SCOREP
-SCOREP_USER_REGION_END( scorep_calcUserVarsAll )
+SCOREP_USER_REGION_END( calcUserVarsAll )
 #endif
   
   delete[] pKin;
@@ -134,8 +134,8 @@ Amplitude::calcAmplitudeAll( GDouble* pdData, GDouble* pdAmps, int iNEvents,
 {
 
 #ifdef SCOREP
-SCOREP_USER_REGION_DEFINE( scorep_calcAmplitudeAll )
-SCOREP_USER_REGION_BEGIN( scorep_calcAmplitudeAll, "scorep_calcAmplitudeAll", SCOREP_USER_REGION_TYPE_COMMON )
+SCOREP_USER_REGION_DEFINE( calcAmplitudeAll )
+SCOREP_USER_REGION_BEGIN( calcAmplitudeAll, "calcAmplitudeAll", SCOREP_USER_REGION_TYPE_COMMON )
 #endif
   
   complex< GDouble > cRes;
@@ -185,7 +185,7 @@ SCOREP_USER_REGION_BEGIN( scorep_calcAmplitudeAll, "scorep_calcAmplitudeAll", SC
   }
 
 #ifdef SCOREP
-SCOREP_USER_REGION_END( scorep_calcAmplitudeAll )
+SCOREP_USER_REGION_END( calcAmplitudeAll )
 #endif
   
   delete[] pKin;
@@ -255,8 +255,8 @@ Amplitude::calcAmplitude( const Kinematics* pKin,
                           GDouble* userVars ) const {
 
 #ifdef SCOREP
-SCOREP_USER_REGION_DEFINE( scorep_calcAmplitude )
-SCOREP_USER_REGION_BEGIN( scorep_calcAmplitude, "scorep_calcAmplitude", SCOREP_USER_REGION_TYPE_COMMON )
+SCOREP_USER_REGION_DEFINE( calcAmplitude )
+SCOREP_USER_REGION_BEGIN( calcAmplitude, "calcAmplitude", SCOREP_USER_REGION_TYPE_COMMON )
 #endif
 
   vector<TLorentzVector> particleList = pKin->particleList();
@@ -292,7 +292,7 @@ SCOREP_USER_REGION_BEGIN( scorep_calcAmplitude, "scorep_calcAmplitude", SCOREP_U
   }
 
 #ifdef SCOREP
-SCOREP_USER_REGION_END( scorep_calcAmplitude )
+SCOREP_USER_REGION_END( calcAmplitude )
 #endif
 
   delete[] pData;
@@ -307,15 +307,15 @@ void
 Amplitude::calcAmplitudeGPU( dim3 dimGrid, dim3 dimBlock, GPU_AMP_PROTO,
                             const vector< int >& perm ) const {
 #ifdef SCOREP
-  SCOREP_USER_REGION_DEFINE( scorep_calcAmplitudeGPU )
-  SCOREP_USER_REGION_BEGIN( scorep_calcAmplitudeGPU, "calcAmplitudeGPU", SCOREP_USER_REGION_TYPE_COMMON )
+  SCOREP_USER_REGION_DEFINE( calcAmplitudeGPU )
+  SCOREP_USER_REGION_BEGIN( calcAmplitudeGPU, "calcAmplitudeGPU", SCOREP_USER_REGION_TYPE_COMMON )
 #endif
 
   	m_currentPermutation = perm;
 	launchGPUKernel( dimGrid, dimBlock, GPU_AMP_ARGS );
   
 #ifdef SCOREP
-  SCOREP_USER_REGION_END( scorep_calcAmplitudeGPU )
+  SCOREP_USER_REGION_END( calcAmplitudeGPU )
 #endif
 }
 #endif
@@ -388,8 +388,8 @@ bool
 Amplitude::updatePar( const string& name ) const {
   
 #ifdef SCOREP
-SCOREP_USER_REGION_DEFINE( scorep_updatePar )
-SCOREP_USER_REGION_BEGIN( scorep_updatePar, "scorep_updatePar", SCOREP_USER_REGION_TYPE_COMMON )
+SCOREP_USER_REGION_DEFINE( updatePar )
+SCOREP_USER_REGION_BEGIN( updatePar, "updatePar", SCOREP_USER_REGION_TYPE_COMMON )
 #endif
 
   
@@ -413,7 +413,7 @@ SCOREP_USER_REGION_BEGIN( scorep_updatePar, "scorep_updatePar", SCOREP_USER_REGI
   }
   
 #ifdef SCOREP
-SCOREP_USER_REGION_END( scorep_updatePar )
+SCOREP_USER_REGION_END( updatePar )
 #endif
   return foundPar;
 }

--- a/AmpTools/IUAmpTools/AmplitudeManager.cc
+++ b/AmpTools/IUAmpTools/AmplitudeManager.cc
@@ -45,9 +45,7 @@ using namespace std;
 #include "IUAmpTools/AmplitudeManager.h"
 #include "IUAmpTools/NormIntInterface.h"
 
-#ifdef VTRACE
-#include "vt_user.h"
-#endif
+#include <scorep/SCOREP_User.h>
 
 AmplitudeManager::AmplitudeManager( const vector< string >& reaction,
                                     const string& reactionName) :
@@ -247,9 +245,8 @@ void
 AmplitudeManager::calcUserVars( AmpVecs& a ) const
 {
 
-#ifdef VTRACE
-  VT_TRACER( "AmplitudeManager::calcUserVars" );
-#endif
+SCOREP_USER_REGION_DEFINE( scorep_calcUserVars )
+SCOREP_USER_REGION_BEGIN( scorep_calcUserVars, "scorep_calcUserVars", SCOREP_USER_REGION_TYPE_COMMON )
 
   const vector< string >& ampNames = getTermNames();
   
@@ -393,6 +390,8 @@ AmplitudeManager::calcUserVars( AmpVecs& a ) const
   a.m_gpuMan.copyUserVarsToGPU( a );
 #endif //GPU_ACCELERATION
 
+SCOREP_USER_REGION_END( scorep_calcUserVars )
+
   return;
 }
 
@@ -400,10 +399,8 @@ AmplitudeManager::calcUserVars( AmpVecs& a ) const
 bool
 AmplitudeManager::calcTerms( AmpVecs& a ) const
 {
-  
-#ifdef VTRACE
-  VT_TRACER( "AmplitudeManager::calcTerms" );
-#endif
+SCOREP_USER_REGION_DEFINE( scorep_calcTerms )
+SCOREP_USER_REGION_BEGIN( scorep_calcTerms, "scorep_calcTerms", SCOREP_USER_REGION_TYPE_COMMON )                           
   
   // on the first pass through this data set be sure to calculate
   // the user data first, if needed, before doing term calculations
@@ -585,16 +582,16 @@ AmplitudeManager::calcTerms( AmpVecs& a ) const
     }
   }
 
+SCOREP_USER_REGION_END( scorep_calcTerms ) 
+
   return modifiedTerm;
 }
 
 double
 AmplitudeManager::calcIntensities( AmpVecs& a ) const
 {
-
-#ifdef VTRACE
-  VT_TRACER( "AmplitudeManager::calcIntensities" );
-#endif
+SCOREP_USER_REGION_DEFINE( scorep_calcIntensities )                                                                                    
+SCOREP_USER_REGION_BEGIN( scorep_calcIntensities, "scorep_calcIntensities", SCOREP_USER_REGION_TYPE_COMMON )                           
 
   // check to be sure destination memory has been allocated
   assert( a.m_pdIntensity );
@@ -689,6 +686,8 @@ AmplitudeManager::calcIntensities( AmpVecs& a ) const
   
   delete[] pdViVjRe;
   delete[] pdViVjIm;
+
+SCOREP_USER_REGION_END( scorep_calcIntensities )
   
   return maxInten;
 }
@@ -697,10 +696,8 @@ AmplitudeManager::calcIntensities( AmpVecs& a ) const
 double
 AmplitudeManager::calcSumLogIntensity( AmpVecs& a ) const
 {
-  
-#ifdef VTRACE
-  VT_TRACER( "AmplitudeManager::calcSumLogIntensity" );
-#endif
+SCOREP_USER_REGION_DEFINE( scorep_calcSumLogIntensity )                                                                                    
+SCOREP_USER_REGION_BEGIN( scorep_calcSumLogIntensity, "scorep_calcSumLogIntensity", SCOREP_USER_REGION_TYPE_COMMON )                           
 
   // this may be inefficienct since there are two
   // loops over events, one here and one in the
@@ -755,6 +752,8 @@ AmplitudeManager::calcSumLogIntensity( AmpVecs& a ) const
   dSumLogI = a.m_gpuMan.calcSumLogIntensity( gpuProdPars, m_sumCoherently );
   
 #endif
+
+SCOREP_USER_REGION_END( scorep_calcSumLogIntensity )  
   
   return( dSumLogI );
 }
@@ -763,10 +762,9 @@ AmplitudeManager::calcSumLogIntensity( AmpVecs& a ) const
 void
 AmplitudeManager::calcIntegrals( AmpVecs& a, int iNGenEvents ) const
 {
-
-#ifdef VTRACE
-  VT_TRACER( "AmplitudeManager::calcIntegrals" );
-#endif
+SCOREP_USER_REGION_DEFINE( scorep_calcIntegralsA )                                                                                    
+SCOREP_USER_REGION_DEFINE( scorep_calcIntegralsB )
+SCOREP_USER_REGION_BEGIN( scorep_calcIntegralsA, "scorep_calcIntegralsA", SCOREP_USER_REGION_TYPE_COMMON )                           
 
   GDouble* integralMatrix = a.m_pdIntegralMatrix;
   
@@ -780,8 +778,10 @@ AmplitudeManager::calcIntegrals( AmpVecs& a, int iNGenEvents ) const
   bool termChanged = calcTerms( a );
   
   // if nothing changed and it isn't the first pass, return
+  SCOREP_USER_REGION_END( scorep_calcIntegralsA )
   if( !termChanged && a.m_integralValid ) return;
     
+  SCOREP_USER_REGION_BEGIN( scorep_calcIntegralsB, "scorep_calcIntegralsB", SCOREP_USER_REGION_TYPE_COMMON )                           
   int iNAmps = a.m_iNTerms;
   
   int i, j, iEvent;
@@ -844,6 +844,8 @@ AmplitudeManager::calcIntegrals( AmpVecs& a, int iNGenEvents ) const
   }
   
   a.m_integralValid = true;
+
+SCOREP_USER_REGION_END( scorep_calcIntegralsB )
 }
 
 const vector< vector< int > >&

--- a/AmpTools/IUAmpTools/AmplitudeManager.cc
+++ b/AmpTools/IUAmpTools/AmplitudeManager.cc
@@ -45,7 +45,9 @@ using namespace std;
 #include "IUAmpTools/AmplitudeManager.h"
 #include "IUAmpTools/NormIntInterface.h"
 
+#ifdef SCOREP
 #include <scorep/SCOREP_User.h>
+#endif
 
 AmplitudeManager::AmplitudeManager( const vector< string >& reaction,
                                     const string& reactionName) :
@@ -245,8 +247,10 @@ void
 AmplitudeManager::calcUserVars( AmpVecs& a ) const
 {
 
+#ifdef SCOREP
 SCOREP_USER_REGION_DEFINE( scorep_calcUserVars )
 SCOREP_USER_REGION_BEGIN( scorep_calcUserVars, "scorep_calcUserVars", SCOREP_USER_REGION_TYPE_COMMON )
+#endif
 
   const vector< string >& ampNames = getTermNames();
   
@@ -390,7 +394,9 @@ SCOREP_USER_REGION_BEGIN( scorep_calcUserVars, "scorep_calcUserVars", SCOREP_USE
   a.m_gpuMan.copyUserVarsToGPU( a );
 #endif //GPU_ACCELERATION
 
+#ifdef SCOREP
 SCOREP_USER_REGION_END( scorep_calcUserVars )
+#endif
 
   return;
 }
@@ -399,8 +405,10 @@ SCOREP_USER_REGION_END( scorep_calcUserVars )
 bool
 AmplitudeManager::calcTerms( AmpVecs& a ) const
 {
+#ifdef SCOREP
 SCOREP_USER_REGION_DEFINE( scorep_calcTerms )
 SCOREP_USER_REGION_BEGIN( scorep_calcTerms, "scorep_calcTerms", SCOREP_USER_REGION_TYPE_COMMON )                           
+#endif
   
   // on the first pass through this data set be sure to calculate
   // the user data first, if needed, before doing term calculations
@@ -582,7 +590,9 @@ SCOREP_USER_REGION_BEGIN( scorep_calcTerms, "scorep_calcTerms", SCOREP_USER_REGI
     }
   }
 
+#ifdef SCOREP
 SCOREP_USER_REGION_END( scorep_calcTerms ) 
+#endif
 
   return modifiedTerm;
 }
@@ -590,8 +600,10 @@ SCOREP_USER_REGION_END( scorep_calcTerms )
 double
 AmplitudeManager::calcIntensities( AmpVecs& a ) const
 {
+#ifdef SCOREP
 SCOREP_USER_REGION_DEFINE( scorep_calcIntensities )                                                                                    
-SCOREP_USER_REGION_BEGIN( scorep_calcIntensities, "scorep_calcIntensities", SCOREP_USER_REGION_TYPE_COMMON )                           
+SCOREP_USER_REGION_BEGIN( scorep_calcIntensities, "scorep_calcIntensities", SCOREP_USER_REGION_TYPE_COMMON )
+#endif
 
   // check to be sure destination memory has been allocated
   assert( a.m_pdIntensity );
@@ -687,7 +699,9 @@ SCOREP_USER_REGION_BEGIN( scorep_calcIntensities, "scorep_calcIntensities", SCOR
   delete[] pdViVjRe;
   delete[] pdViVjIm;
 
+#ifdef SCOREP
 SCOREP_USER_REGION_END( scorep_calcIntensities )
+#endif
   
   return maxInten;
 }
@@ -696,8 +710,10 @@ SCOREP_USER_REGION_END( scorep_calcIntensities )
 double
 AmplitudeManager::calcSumLogIntensity( AmpVecs& a ) const
 {
+#ifdef SCOREP
 SCOREP_USER_REGION_DEFINE( scorep_calcSumLogIntensity )                                                                                    
-SCOREP_USER_REGION_BEGIN( scorep_calcSumLogIntensity, "scorep_calcSumLogIntensity", SCOREP_USER_REGION_TYPE_COMMON )                           
+SCOREP_USER_REGION_BEGIN( scorep_calcSumLogIntensity, "scorep_calcSumLogIntensity", SCOREP_USER_REGION_TYPE_COMMON )
+#endif
 
   // this may be inefficienct since there are two
   // loops over events, one here and one in the
@@ -753,7 +769,9 @@ SCOREP_USER_REGION_BEGIN( scorep_calcSumLogIntensity, "scorep_calcSumLogIntensit
   
 #endif
 
-SCOREP_USER_REGION_END( scorep_calcSumLogIntensity )  
+#ifdef SCOREP
+SCOREP_USER_REGION_END( scorep_calcSumLogIntensity )
+#endif
   
   return( dSumLogI );
 }
@@ -762,9 +780,11 @@ SCOREP_USER_REGION_END( scorep_calcSumLogIntensity )
 void
 AmplitudeManager::calcIntegrals( AmpVecs& a, int iNGenEvents ) const
 {
+#ifdef SCOREP
 SCOREP_USER_REGION_DEFINE( scorep_calcIntegralsA )                                                                                    
 SCOREP_USER_REGION_DEFINE( scorep_calcIntegralsB )
-SCOREP_USER_REGION_BEGIN( scorep_calcIntegralsA, "scorep_calcIntegralsA", SCOREP_USER_REGION_TYPE_COMMON )                           
+SCOREP_USER_REGION_BEGIN( scorep_calcIntegralsA, "scorep_calcIntegralsA", SCOREP_USER_REGION_TYPE_COMMON )
+#endif
 
   GDouble* integralMatrix = a.m_pdIntegralMatrix;
   
@@ -778,10 +798,14 @@ SCOREP_USER_REGION_BEGIN( scorep_calcIntegralsA, "scorep_calcIntegralsA", SCOREP
   bool termChanged = calcTerms( a );
   
   // if nothing changed and it isn't the first pass, return
+#ifdef SCOREP
   SCOREP_USER_REGION_END( scorep_calcIntegralsA )
+#endif
   if( !termChanged && a.m_integralValid ) return;
     
-  SCOREP_USER_REGION_BEGIN( scorep_calcIntegralsB, "scorep_calcIntegralsB", SCOREP_USER_REGION_TYPE_COMMON )                           
+#ifdef SCOREP
+  SCOREP_USER_REGION_BEGIN( scorep_calcIntegralsB, "scorep_calcIntegralsB", SCOREP_USER_REGION_TYPE_COMMON )
+#endif
   int iNAmps = a.m_iNTerms;
   
   int i, j, iEvent;
@@ -845,7 +869,9 @@ SCOREP_USER_REGION_BEGIN( scorep_calcIntegralsA, "scorep_calcIntegralsA", SCOREP
   
   a.m_integralValid = true;
 
+#ifdef SCOREP
 SCOREP_USER_REGION_END( scorep_calcIntegralsB )
+#endif
 }
 
 const vector< vector< int > >&

--- a/AmpTools/IUAmpTools/AmplitudeManager.cc
+++ b/AmpTools/IUAmpTools/AmplitudeManager.cc
@@ -248,8 +248,8 @@ AmplitudeManager::calcUserVars( AmpVecs& a ) const
 {
 
 #ifdef SCOREP
-SCOREP_USER_REGION_DEFINE( scorep_calcUserVars )
-SCOREP_USER_REGION_BEGIN( scorep_calcUserVars, "scorep_calcUserVars", SCOREP_USER_REGION_TYPE_COMMON )
+SCOREP_USER_REGION_DEFINE( calcUserVars )
+SCOREP_USER_REGION_BEGIN( calcUserVars, "calcUserVars", SCOREP_USER_REGION_TYPE_COMMON )
 #endif
 
   const vector< string >& ampNames = getTermNames();
@@ -395,7 +395,7 @@ SCOREP_USER_REGION_BEGIN( scorep_calcUserVars, "scorep_calcUserVars", SCOREP_USE
 #endif //GPU_ACCELERATION
 
 #ifdef SCOREP
-SCOREP_USER_REGION_END( scorep_calcUserVars )
+SCOREP_USER_REGION_END( calcUserVars )
 #endif
 
   return;
@@ -406,8 +406,8 @@ bool
 AmplitudeManager::calcTerms( AmpVecs& a ) const
 {
 #ifdef SCOREP
-SCOREP_USER_REGION_DEFINE( scorep_calcTerms )
-SCOREP_USER_REGION_BEGIN( scorep_calcTerms, "scorep_calcTerms", SCOREP_USER_REGION_TYPE_COMMON )                           
+SCOREP_USER_REGION_DEFINE( calcTerms )
+SCOREP_USER_REGION_BEGIN( calcTerms, "calcTerms", SCOREP_USER_REGION_TYPE_COMMON )                           
 #endif
   
   // on the first pass through this data set be sure to calculate
@@ -591,7 +591,7 @@ SCOREP_USER_REGION_BEGIN( scorep_calcTerms, "scorep_calcTerms", SCOREP_USER_REGI
   }
 
 #ifdef SCOREP
-SCOREP_USER_REGION_END( scorep_calcTerms ) 
+SCOREP_USER_REGION_END( calcTerms ) 
 #endif
 
   return modifiedTerm;
@@ -601,8 +601,8 @@ double
 AmplitudeManager::calcIntensities( AmpVecs& a ) const
 {
 #ifdef SCOREP
-SCOREP_USER_REGION_DEFINE( scorep_calcIntensities )                                                                                    
-SCOREP_USER_REGION_BEGIN( scorep_calcIntensities, "scorep_calcIntensities", SCOREP_USER_REGION_TYPE_COMMON )
+SCOREP_USER_REGION_DEFINE( calcIntensities )                                                                                    
+SCOREP_USER_REGION_BEGIN( calcIntensities, "calcIntensities", SCOREP_USER_REGION_TYPE_COMMON )
 #endif
 
   // check to be sure destination memory has been allocated
@@ -700,7 +700,7 @@ SCOREP_USER_REGION_BEGIN( scorep_calcIntensities, "scorep_calcIntensities", SCOR
   delete[] pdViVjIm;
 
 #ifdef SCOREP
-SCOREP_USER_REGION_END( scorep_calcIntensities )
+SCOREP_USER_REGION_END( calcIntensities )
 #endif
   
   return maxInten;
@@ -711,8 +711,8 @@ double
 AmplitudeManager::calcSumLogIntensity( AmpVecs& a ) const
 {
 #ifdef SCOREP
-SCOREP_USER_REGION_DEFINE( scorep_calcSumLogIntensity )                                                                                    
-SCOREP_USER_REGION_BEGIN( scorep_calcSumLogIntensity, "scorep_calcSumLogIntensity", SCOREP_USER_REGION_TYPE_COMMON )
+SCOREP_USER_REGION_DEFINE( calcSumLogIntensity )                                                                                    
+SCOREP_USER_REGION_BEGIN( calcSumLogIntensity, "calcSumLogIntensity", SCOREP_USER_REGION_TYPE_COMMON )
 #endif
 
   // this may be inefficienct since there are two
@@ -770,7 +770,7 @@ SCOREP_USER_REGION_BEGIN( scorep_calcSumLogIntensity, "scorep_calcSumLogIntensit
 #endif
 
 #ifdef SCOREP
-SCOREP_USER_REGION_END( scorep_calcSumLogIntensity )
+SCOREP_USER_REGION_END( calcSumLogIntensity )
 #endif
   
   return( dSumLogI );
@@ -781,9 +781,9 @@ void
 AmplitudeManager::calcIntegrals( AmpVecs& a, int iNGenEvents ) const
 {
 #ifdef SCOREP
-SCOREP_USER_REGION_DEFINE( scorep_calcIntegralsA )                                                                                    
-SCOREP_USER_REGION_DEFINE( scorep_calcIntegralsB )
-SCOREP_USER_REGION_BEGIN( scorep_calcIntegralsA, "scorep_calcIntegralsA", SCOREP_USER_REGION_TYPE_COMMON )
+SCOREP_USER_REGION_DEFINE( calcIntegralsA )                                                                                    
+SCOREP_USER_REGION_DEFINE( calcIntegralsB )
+SCOREP_USER_REGION_BEGIN( calcIntegralsA, "calcIntegralsA", SCOREP_USER_REGION_TYPE_COMMON )
 #endif
 
   GDouble* integralMatrix = a.m_pdIntegralMatrix;
@@ -799,12 +799,12 @@ SCOREP_USER_REGION_BEGIN( scorep_calcIntegralsA, "scorep_calcIntegralsA", SCOREP
   
   // if nothing changed and it isn't the first pass, return
 #ifdef SCOREP
-  SCOREP_USER_REGION_END( scorep_calcIntegralsA )
+  SCOREP_USER_REGION_END( calcIntegralsA )
 #endif
   if( !termChanged && a.m_integralValid ) return;
     
 #ifdef SCOREP
-  SCOREP_USER_REGION_BEGIN( scorep_calcIntegralsB, "scorep_calcIntegralsB", SCOREP_USER_REGION_TYPE_COMMON )
+  SCOREP_USER_REGION_BEGIN( calcIntegralsB, "calcIntegralsB", SCOREP_USER_REGION_TYPE_COMMON )
 #endif
   int iNAmps = a.m_iNTerms;
   
@@ -870,7 +870,7 @@ SCOREP_USER_REGION_BEGIN( scorep_calcIntegralsA, "scorep_calcIntegralsA", SCOREP
   a.m_integralValid = true;
 
 #ifdef SCOREP
-SCOREP_USER_REGION_END( scorep_calcIntegralsB )
+SCOREP_USER_REGION_END( calcIntegralsB )
 #endif
 }
 

--- a/AmpTools/IUAmpTools/LikelihoodCalculator.cc
+++ b/AmpTools/IUAmpTools/LikelihoodCalculator.cc
@@ -49,9 +49,7 @@
 #include "MinuitInterface/MinuitParameterManager.h"
 #include "MinuitInterface/MinuitParameter.h"
 
-#ifdef VTRACE
-#include "vt_user.h"
-#endif
+#include <scorep/SCOREP_User.h>
 
 LikelihoodCalculator::LikelihoodCalculator( const IntensityManager& intenManager,
                                             const NormIntInterface& normInt,
@@ -106,10 +104,8 @@ LikelihoodCalculator::numSignalEvents(){
 
 double
 LikelihoodCalculator::normIntTerm(){
-  
-#ifdef VTRACE
-  VT_TRACER( "LikelihoodCalculator::normIntTerm" );
-#endif
+SCOREP_USER_REGION_DEFINE( scorep_normIntTerm )                                                                                    
+SCOREP_USER_REGION_BEGIN( scorep_normIntTerm, "scorep_normIntTerm", SCOREP_USER_REGION_TYPE_COMMON )                           
   
   // check to be sure we can actually perform a computation of the
   // normalization integrals in case we have floating parameters
@@ -181,6 +177,8 @@ LikelihoodCalculator::normIntTerm(){
   }
   
   m_firstNormIntCalc = false;
+
+  SCOREP_USER_REGION_END( scorep_normIntTerm ) 
   
   if( m_hasBackground ){
     
@@ -203,14 +201,13 @@ LikelihoodCalculator::normIntTerm(){
     
     return normTerm;
   }
+
 }
 
 double
 LikelihoodCalculator::dataTerm( bool suppressError ){
-  
-#ifdef VTRACE
-  VT_TRACER( "LikelihoodCalculator::dataTerm" );
-#endif
+SCOREP_USER_REGION_DEFINE( scorep_dataTerm )                                                                                    
+SCOREP_USER_REGION_BEGIN( scorep_dataTerm, "scorep_dataTerm", SCOREP_USER_REGION_TYPE_COMMON )                           
 
   if( m_firstDataCalc ) {
     
@@ -289,6 +286,8 @@ LikelihoodCalculator::dataTerm( bool suppressError ){
   }
   
   m_firstDataCalc = false;
+
+SCOREP_USER_REGION_END( scorep_dataTerm )  
   
   return sumLnI;
 }

--- a/AmpTools/IUAmpTools/LikelihoodCalculator.cc
+++ b/AmpTools/IUAmpTools/LikelihoodCalculator.cc
@@ -107,8 +107,8 @@ LikelihoodCalculator::numSignalEvents(){
 double
 LikelihoodCalculator::normIntTerm(){
 #ifdef SCOREP
-SCOREP_USER_REGION_DEFINE( scorep_normIntTerm )                                                                                    
-SCOREP_USER_REGION_BEGIN( scorep_normIntTerm, "scorep_normIntTerm", SCOREP_USER_REGION_TYPE_COMMON )
+SCOREP_USER_REGION_DEFINE( normIntTerm )                                                                                    
+SCOREP_USER_REGION_BEGIN( normIntTerm, "normIntTerm", SCOREP_USER_REGION_TYPE_COMMON )
 #endif
   
   // check to be sure we can actually perform a computation of the
@@ -183,7 +183,7 @@ SCOREP_USER_REGION_BEGIN( scorep_normIntTerm, "scorep_normIntTerm", SCOREP_USER_
   m_firstNormIntCalc = false;
 
 #ifdef SCOREP
-  SCOREP_USER_REGION_END( scorep_normIntTerm )
+  SCOREP_USER_REGION_END( normIntTerm )
 #endif
   
   if( m_hasBackground ){
@@ -213,8 +213,8 @@ SCOREP_USER_REGION_BEGIN( scorep_normIntTerm, "scorep_normIntTerm", SCOREP_USER_
 double
 LikelihoodCalculator::dataTerm( bool suppressError ){
 #ifdef SCOREP
-SCOREP_USER_REGION_DEFINE( scorep_dataTerm )                                                                                    
-SCOREP_USER_REGION_BEGIN( scorep_dataTerm, "scorep_dataTerm", SCOREP_USER_REGION_TYPE_COMMON )
+SCOREP_USER_REGION_DEFINE( dataTerm )                                                                                    
+SCOREP_USER_REGION_BEGIN( dataTerm, "dataTerm", SCOREP_USER_REGION_TYPE_COMMON )
 #endif
 
   if( m_firstDataCalc ) {
@@ -296,7 +296,7 @@ SCOREP_USER_REGION_BEGIN( scorep_dataTerm, "scorep_dataTerm", SCOREP_USER_REGION
   m_firstDataCalc = false;
 
 #ifdef SCOREP
-SCOREP_USER_REGION_END( scorep_dataTerm )
+SCOREP_USER_REGION_END( dataTerm )
 #endif
   
   return sumLnI;

--- a/AmpTools/IUAmpTools/LikelihoodCalculator.cc
+++ b/AmpTools/IUAmpTools/LikelihoodCalculator.cc
@@ -49,7 +49,9 @@
 #include "MinuitInterface/MinuitParameterManager.h"
 #include "MinuitInterface/MinuitParameter.h"
 
+#ifdef SCOREP
 #include <scorep/SCOREP_User.h>
+#endif
 
 LikelihoodCalculator::LikelihoodCalculator( const IntensityManager& intenManager,
                                             const NormIntInterface& normInt,
@@ -104,8 +106,10 @@ LikelihoodCalculator::numSignalEvents(){
 
 double
 LikelihoodCalculator::normIntTerm(){
+#ifdef SCOREP
 SCOREP_USER_REGION_DEFINE( scorep_normIntTerm )                                                                                    
-SCOREP_USER_REGION_BEGIN( scorep_normIntTerm, "scorep_normIntTerm", SCOREP_USER_REGION_TYPE_COMMON )                           
+SCOREP_USER_REGION_BEGIN( scorep_normIntTerm, "scorep_normIntTerm", SCOREP_USER_REGION_TYPE_COMMON )
+#endif
   
   // check to be sure we can actually perform a computation of the
   // normalization integrals in case we have floating parameters
@@ -178,7 +182,9 @@ SCOREP_USER_REGION_BEGIN( scorep_normIntTerm, "scorep_normIntTerm", SCOREP_USER_
   
   m_firstNormIntCalc = false;
 
-  SCOREP_USER_REGION_END( scorep_normIntTerm ) 
+#ifdef SCOREP
+  SCOREP_USER_REGION_END( scorep_normIntTerm )
+#endif
   
   if( m_hasBackground ){
     
@@ -206,8 +212,10 @@ SCOREP_USER_REGION_BEGIN( scorep_normIntTerm, "scorep_normIntTerm", SCOREP_USER_
 
 double
 LikelihoodCalculator::dataTerm( bool suppressError ){
+#ifdef SCOREP
 SCOREP_USER_REGION_DEFINE( scorep_dataTerm )                                                                                    
-SCOREP_USER_REGION_BEGIN( scorep_dataTerm, "scorep_dataTerm", SCOREP_USER_REGION_TYPE_COMMON )                           
+SCOREP_USER_REGION_BEGIN( scorep_dataTerm, "scorep_dataTerm", SCOREP_USER_REGION_TYPE_COMMON )
+#endif
 
   if( m_firstDataCalc ) {
     
@@ -287,7 +295,9 @@ SCOREP_USER_REGION_BEGIN( scorep_dataTerm, "scorep_dataTerm", SCOREP_USER_REGION
   
   m_firstDataCalc = false;
 
-SCOREP_USER_REGION_END( scorep_dataTerm )  
+#ifdef SCOREP
+SCOREP_USER_REGION_END( scorep_dataTerm )
+#endif
   
   return sumLnI;
 }

--- a/AmpTools/Makefile
+++ b/AmpTools/Makefile
@@ -9,20 +9,15 @@ include $(AMPTOOLS_HOME)/Makefile.settings
 # Most things below here probably don't need to be changed
 #
 # (expert option for profile and tracing)
-# to build code instrumented for Vampir Trace use VTRACE=1
+# to build code instrumented for Score-P use SCOREP=1
 
-ifdef VTRACE
-CXX := vtcxx -vt:inst manual
+ifdef SCOREP
+CXX := scorep-g++ --user
 
-ifdef MPI
-CXX += -vt:mpi
+CXX_FLAGS += -DSCOREP_USER_ENABLE
 endif
 
-NVCC := vtnvcc
-CXX_FLAGS += -DVTRACE
-endif
-
-INC_DIR :=  -I.. -I$(shell root-config --incdir)
+INC_DIR :=  -I.. -I$(shell root-config --incdir) -I$(SCOREP_INC)
 CXX_FLAGS += $(shell root-config --cflags)
 
 SRCDIRS := UpRootMinuit MinuitInterface IUAmpTools
@@ -39,6 +34,9 @@ endif
 # check if MPI build is requested
 ifdef MPI
 CXX := $(MPICXX)
+ifdef SCOREP
+CXX := scorep --mpp=mpi --user mpicxx
+endif
 SRCDIRS += IUAmpToolsMPI
 CXX_FLAGS += -DUSE_MPI
 SUFFIX := $(SUFFIX)_MPI

--- a/Makefile.settings
+++ b/Makefile.settings
@@ -30,7 +30,7 @@ NVCC :=  nvcc
 NVCC_FLAGS := -m64
 
 ifndef GPU_ARCH
-GPU_ARCH := sm_20
+GPU_ARCH := sm_70
 endif
 
 NVCC_FLAGS += -arch=$(GPU_ARCH)


### PR DESCRIPTION
Replace Vampir calls with corresponding Score-p calls. Makes use of user instrumentation of the code in specific places to enable profiling.