### PR TITLE
Use more fp32

### DIFF
--- a/AmpTools/GPUManager/GPUAmpProductKernel.cu
+++ b/AmpTools/GPUManager/GPUAmpProductKernel.cu
@@ -57,6 +57,7 @@ amp_kernel( GDouble* pfDevAmps, GDouble* pfDevVVStar, GDouble* pfDevWeights,
 
     // index in the array of V_alpha * conj( V_beta )
     int vInd = iA*(iA+1)/2;
+
     
     // index to amplitude A_beta for the ith event
     int aIndB = 2*i;
@@ -69,6 +70,7 @@ amp_kernel( GDouble* pfDevAmps, GDouble* pfDevVVStar, GDouble* pfDevWeights,
 	    // index to amplitude A_beta for the ith event
       // (reduce computations by incrementing at end of loop)
       //     int aIndB = i + 2*nEvents*iB;
+
 
       // only compute the real part of the intensity since
       // the imaginary part should sum to zero
@@ -92,7 +94,7 @@ amp_kernel( GDouble* pfDevAmps, GDouble* pfDevVVStar, GDouble* pfDevWeights,
     
     aIndA += 2*nEvents;
 	}
-	
+
 	pdDevRes[i] = (double)(pfDevWeights[i] * G_LOG( fSumRe ));
 }
 

--- a/AmpTools/GPUManager/GPUAmpProductKernel.cu
+++ b/AmpTools/GPUManager/GPUAmpProductKernel.cu
@@ -38,7 +38,7 @@
 
 __global__ void
 amp_kernel( GDouble* pfDevAmps, GDouble* pfDevVVStar, GDouble* pfDevWeights, 
-            int nAmps, int nEvents, GDouble* pfDevRes )
+            int nAmps, int nEvents, double* pdDevRes )
 {
 	int i = threadIdx.x + GPU_BLOCK_SIZE_X * threadIdx.y + 
             ( blockIdx.x + blockIdx.y * gridDim.x ) * GPU_BLOCK_SIZE_SQ;
@@ -93,14 +93,14 @@ amp_kernel( GDouble* pfDevAmps, GDouble* pfDevVVStar, GDouble* pfDevWeights,
     aIndA += 2*nEvents;
 	}
 	
-	pfDevRes[i] = pfDevWeights[i] * G_LOG( fSumRe );
+	pdDevRes[i] = (double)(pfDevWeights[i] * G_LOG( fSumRe ));
 }
 
 extern "C" void GPU_ExecAmpKernel( dim3 dimGrid, dim3 dimBlock, 
      GDouble* pfDevAmps, GDouble* pfDevVVStar, GDouble* pfDevWeights,
-     int nAmps, int nEvents, GDouble* pfDevRes )
+     int nAmps, int nEvents, double* pdDevRes )
 {
 	amp_kernel<<< dimGrid, dimBlock >>>( pfDevAmps, pfDevVVStar, pfDevWeights, 
-                                       nAmps, nEvents, pfDevRes );
+                                       nAmps, nEvents, pdDevRes );
 }
 

--- a/AmpTools/GPUManager/GPUCustomTypes.h
+++ b/AmpTools/GPUManager/GPUCustomTypes.h
@@ -79,7 +79,29 @@ using namespace std;
 // reduce memory consumption at the risk of minimization instability for
 // large data sets.  (Any sums are maintained in double precision always.)
 
-#ifdef AMPTOOLS_GDOUBLE_FP64  // double precision:
+#ifdef AMPTOOLS_GDOUBLE_FP32  // single precision
+
+typedef float GDouble;
+
+//MACROS FOR DIFFERENT PRECISION OPERATIONS
+#define G_SIN(a)  sinf(a)
+#define G_ASIN(a) asinf(a)
+#define G_COS(a)  cosf(a)
+#define G_ACOS(a) acosf(a)
+
+#define G_ATAN2(a,b)  atan2f(a,b)
+#define G_ATAN(a) atanf(a)
+#define G_LOG(a)  logf(a)
+
+#define G_FABS(a)  fabsf(a)
+#define G_POW(a,b)  powf(a,b)
+#define G_EXP(a) expf(a)
+#define G_SQRT(a)  sqrtf(a)
+
+#define PI 3.141592653589793f
+#define D_EPS    1.e-10f
+
+#else  // default double precision:  AMPTOOLS_GDOUBLE_FP64
 
 typedef double GDouble;
 
@@ -101,29 +123,7 @@ typedef double GDouble;
 #define PI 3.141592653589793
 #define D_EPS		1.e-10
 
-#else // single precision: AMPTOOLS_GDOUBLE_FP32
-
-typedef float GDouble;
-
-//MACROS FOR DIFFERENT PRECISION OPERATIONS
-#define G_SIN(a)	sinf(a)
-#define G_ASIN(a) asinf(a)
-#define G_COS(a)  cosf(a)
-#define G_ACOS(a) acosf(a)
-
-#define G_ATAN2(a,b)	atan2f(a,b)
-#define G_ATAN(a) atanf(a)
-#define G_LOG(a)	logf(a)
-
-#define G_FABS(a)	fabsf(a)
-#define G_POW(a,b)	powf(a,b)
-#define G_EXP(a) expf(a)
-#define G_SQRT(a)	sqrtf(a)
-
-#define PI 3.141592653589793f
-#define D_EPS		1.e-10f
-
-#endif // AMPTOOLS_GDOUBLE_FP64
+#endif // AMPTOOLS_GDOUBLE_FP32
 
 //Shortcut macros
 #define SQ(a) ((a)*(a)) 

--- a/AmpTools/GPUManager/GPUCustomTypes.h
+++ b/AmpTools/GPUManager/GPUCustomTypes.h
@@ -86,7 +86,7 @@ using namespace std;
 // cancellation in terms which is difficult to 
 // achieve numerically with single precision
 
-#define USE_DOUBLE_PRECISION
+//#define USE_DOUBLE_PRECISION
 
 #ifdef USE_DOUBLE_PRECISION  // double precision:
 

--- a/AmpTools/GPUManager/GPUCustomTypes.h
+++ b/AmpTools/GPUManager/GPUCustomTypes.h
@@ -73,22 +73,13 @@ using namespace std;
 
 #define COPY_P4(a1,a2) GDouble a2[4]; for( int zzz = 0; zzz < 4; ++zzz ) a2[zzz] = a1[zzz];
 
+// The GDouble type is used for event-level objects like four-vectors,
+// weights, or individual event amplitudes.  The type is double by default
+// but can be set at compile time to be float to enhance perfomance and
+// reduce memory consumption at the risk of minimization instability for
+// large data sets.  (Any sums are maintained in double precision always.)
 
-// Use this flag to turn on double precision
-// (MPI portions of the code depend on this also)
-// 
-// NOTE: 64-bit floating point math is only
-// supported on hardware with 1.3 or higher
-// compute capability
-//
-// single precision should be used with caution;
-// some intensity calculations may be sensitive to
-// cancellation in terms which is difficult to 
-// achieve numerically with single precision
-
-//#define USE_DOUBLE_PRECISION
-
-#ifdef USE_DOUBLE_PRECISION  // double precision:
+#ifdef AMPTOOLS_GDOUBLE_FP64  // double precision:
 
 typedef double GDouble;
 
@@ -110,7 +101,7 @@ typedef double GDouble;
 #define PI 3.141592653589793
 #define D_EPS		1.e-10
 
-#else // single precision:
+#else // single precision: AMPTOOLS_GDOUBLE_FP32
 
 typedef float GDouble;
 
@@ -132,7 +123,7 @@ typedef float GDouble;
 #define PI 3.141592653589793f
 #define D_EPS		1.e-10f
 
-#endif // USE_DOUBLE_PRECISION
+#endif // AMPTOOLS_GDOUBLE_FP64
 
 //Shortcut macros
 #define SQ(a) ((a)*(a)) 

--- a/AmpTools/GPUManager/GPUKernel.h
+++ b/AmpTools/GPUManager/GPUKernel.h
@@ -41,7 +41,7 @@
 
 extern "C" void GPU_ExecAmpKernel(dim3 dimGrid,dim3 dimBlock,GDouble* pfDevAmps,
                                   GDouble* pfDevVVStar, GDouble* pfDevWeights,
-                                  int nAmps, int nEvents, GDouble* pfDevRes);
+                                  int nAmps, int nEvents, double* pfDevRes);
 
 extern "C" void GPU_ExecFactPermKernel( dim3 dimGrid, dim3 dimBlock,
                                         GDouble* pfDevAmps, GDouble* pcDevCalcAmp,

--- a/AmpTools/GPUManager/GPUKernel.h
+++ b/AmpTools/GPUManager/GPUKernel.h
@@ -49,7 +49,7 @@ extern "C" void GPU_ExecFactPermKernel( dim3 dimGrid, dim3 dimBlock,
 
 
 extern "C" void GPU_ExecNICalcKernel( dim3 dimGrid, dim3 dimBlock, unsigned int sharedSize,
-                                      int nElements, GDouble* pfDevNICalc,
+                                      int nElements, double* pdDevNICalc,
                                       GDouble* pfDevAmps, GDouble* pfDevWeights,
                                       int nEvents, int nTrueEvents );
 

--- a/AmpTools/GPUManager/GPUManager.h
+++ b/AmpTools/GPUManager/GPUManager.h
@@ -100,8 +100,8 @@ public:
   double calcSumLogIntensity( const vector< complex< double > >& prodCoef,
                               const vector< vector< bool > >& cohMtx );
 
-  void calcIntegrals( GDouble* result, int nElements, const vector<int>& iIndex,
-                     const vector<int>& jIndex );
+  void calcIntegrals( double* result, int nElements, const vector<int>& iIndex,
+                      const vector<int>& jIndex );
   
   // General utils:
   static int calcNEventsGPU( int iNEvents ){
@@ -126,7 +126,7 @@ private:
   // array sizes
   unsigned long long m_iGDoubleEventArrSize;
   unsigned long long m_iDoubleEventArrSize;
-  unsigned long long m_iTrueEventArrSize;
+  unsigned long long m_iDoubleTrueEventArrSize;
   unsigned long long m_iAmpArrSize;
   unsigned int m_iVArrSize;
   unsigned int m_iNICalcSize;
@@ -135,7 +135,7 @@ private:
   GDouble* m_pcCalcAmp;
   
   GDouble* m_pfVVStar;
-  GDouble* m_pfRes;
+  double* m_pdRes;
   
   //Device Arrays 
   GDouble* m_pfDevData;

--- a/AmpTools/GPUManager/GPUManager.h
+++ b/AmpTools/GPUManager/GPUManager.h
@@ -118,13 +118,14 @@ private:
   
   // array dimensions
   unsigned int m_iNParticles;
-  unsigned long long m_iNEvents;
-  unsigned long long m_iNTrueEvents;
+  unsigned long m_iNEvents;
+  unsigned long m_iNTrueEvents;
   unsigned int m_iNAmps;
   unsigned int m_iNUserVars;
   
   // array sizes
-  unsigned long long m_iEventArrSize;
+  unsigned long long m_iGDoubleEventArrSize;
+  unsigned long long m_iDoubleEventArrSize;
   unsigned long long m_iTrueEventArrSize;
   unsigned long long m_iAmpArrSize;
   unsigned int m_iVArrSize;
@@ -145,10 +146,10 @@ private:
   
   GDouble* m_pfDevAmps;
   GDouble* m_pfDevVVStar;
-  GDouble* m_pfDevNICalc;
+  double* m_pdDevNICalc;
   
-  GDouble* m_pfDevRes;
-  GDouble* m_pfDevREDUCE;
+  double* m_pdDevRes;
+  double* m_pdDevREDUCE;
   
   // CUDA Thread and Grid sizes
   unsigned int m_iDimGridX;

--- a/AmpTools/IUAmpTools/AmpVecs.cc
+++ b/AmpTools/IUAmpTools/AmpVecs.cc
@@ -303,7 +303,7 @@ AmpVecs::allocateTerms( const IntensityManager& intenMan, bool bAllocIntensity )
     assert(false);
   }
   
-  m_pdIntegralMatrix = new GDouble[2*m_iNTerms*m_iNTerms];
+  m_pdIntegralMatrix = new double[2*m_iNTerms*m_iNTerms];
   
   //Allocate the Intensity only when needed
   if( bAllocIntensity )

--- a/AmpTools/IUAmpTools/AmpVecs.h
+++ b/AmpTools/IUAmpTools/AmpVecs.h
@@ -148,7 +148,7 @@ struct AmpVecs
    * that is useful for calculating normalization integrals.
    */
   
-  GDouble* m_pdIntegralMatrix;
+  double* m_pdIntegralMatrix;
   
   /**
    * An array of length iNEvents that stores the intensity for each event.

--- a/AmpTools/IUAmpTools/AmplitudeManager.cc
+++ b/AmpTools/IUAmpTools/AmplitudeManager.cc
@@ -803,7 +803,7 @@ SCOREP_USER_REGION_DEFINE( calcIntegralsB )
 SCOREP_USER_REGION_BEGIN( calcIntegralsA, "calcIntegralsA", SCOREP_USER_REGION_TYPE_COMMON )
 #endif
 
-  GDouble* integralMatrix = a.m_pdIntegralMatrix;
+  double* integralMatrix = a.m_pdIntegralMatrix;
   
   // amp -> amp* -> value
   assert( iNGenEvents );
@@ -839,7 +839,7 @@ SCOREP_USER_REGION_BEGIN( calcIntegralsA, "calcIntegralsA", SCOREP_USER_REGION_T
   vector<int> jIndex(maxNIElements);
   
   // this stores the real and imaginary parts of the term calculations
-  vector<GDouble> result(maxNIElements*2);
+  vector<double> result(maxNIElements*2);
   
   // now figure out which elements of the NI matrix need to be computed
   int i, j;
@@ -917,9 +917,9 @@ SCOREP_USER_REGION_BEGIN( calcIntegralsA, "calcIntegralsA", SCOREP_USER_REGION_T
     int j = jIndex[iTerm];
 	
     integralMatrix[2*i*iNAmps+2*j] = result[2*iTerm] /
-      static_cast< GDouble >( iNGenEvents );
+      static_cast< double >( iNGenEvents );
     integralMatrix[2*i*iNAmps+2*j+1] = result[2*iTerm+1] /
-      static_cast< GDouble >( iNGenEvents );
+      static_cast< double >( iNGenEvents );
     
     if( i != j ) {
       

--- a/AmpTools/IUAmpTools/AmplitudeManager.cc
+++ b/AmpTools/IUAmpTools/AmplitudeManager.cc
@@ -658,12 +658,17 @@ SCOREP_USER_REGION_BEGIN( calcIntensities, "calcIntensities", SCOREP_USER_REGION
     for( j = 0; j <= i; j++ ){
       
       cTmp = productionFactor( i ) * conj( productionFactor( j ) );
-            
-      if( termsAreRenormalized() ){
-        
-        cTmp /= sqrt( normInt()->ampInt( ampNames[i], ampNames[i] ) *
-                      normInt()->ampInt( ampNames[j], ampNames[j] ) );
-      }
+
+      // This is a scaling of the intensity so that the "data term"
+      // in the ln likelihood grows like N instead of N*ln(N) -- this
+      // makes the scaling consistent with the norm int term, but
+      // shifts the likelihood at minimum.  This may be bothersome
+      // to users comparing across versions so leave an option for
+      // turning it off at compile time.
+
+#ifndef USE_LEGACY_LN_LIK_SCALING
+      cTmp /= a.m_iNEvents;
+#endif
       
       pdViVjRe[i*(i+1)/2+j] = cTmp.real();
       pdViVjIm[i*(i+1)/2+j] = cTmp.imag();
@@ -767,11 +772,17 @@ SCOREP_USER_REGION_BEGIN( calcSumLogIntensity, "calcSumLogIntensity", SCOREP_USE
   for( int i = 0; i < ampNames.size(); ++i ){
     
     gpuProdPars[i] = productionFactor( ampNames[i] );
-    
-    if( termsAreRenormalized() ){
-      
-      gpuProdPars[i] /= sqrt( normInt()->ampInt( ampNames[i], ampNames[i] ) );
-    }
+
+    // This is a scaling of the intensity so that the "data term"
+    // in the ln likelihood grows like N instead of N*ln(N) -- this
+    // makes the scaling consistent with the norm int term, but
+    // shifts the likelihood at minimum.  This may be bothersome
+    // to users comparing across versions so leave an option for
+    // turning it off at compile time.
+
+#ifndef USE_LEGACY_LN_LIK_SCALING
+    gpuProdPars[i] /= sqrt( a.m_iNEvents );
+#endif
   }
   
   // need to explicitly do amplitude calculation

--- a/AmpTools/IUAmpTools/FitResults.cc
+++ b/AmpTools/IUAmpTools/FitResults.cc
@@ -686,8 +686,7 @@ FitResults::writeResults( const string& outFile ) const {
     }
     else{
       ni->forceCacheUpdate();
-      ni->exportNormIntCache( output,
-                              m_intenManVec[i]->termsAreRenormalized() );
+      ni->exportNormIntCache( output );
     }
   }
   

--- a/AmpTools/IUAmpTools/IntensityManager.cc
+++ b/AmpTools/IUAmpTools/IntensityManager.cc
@@ -55,9 +55,7 @@
 
 IntensityManager::IntensityManager( const vector< string >& reaction,
                                    const string& reactionName) :
-m_reactionName(reactionName),
-m_renormalizeTerms( false ),
-m_normInt( NULL )
+m_reactionName(reactionName)
 {
 
 }
@@ -220,22 +218,3 @@ IntensityManager::setParValue( const string& name, const string& parName,
     m_termScaleVec[m_termIndex[name]].setValue( val );
   }
 }
-
-/*
- * disable these for now until a fix is made to the NormIntInterface to prevent
- * problems with free parameters in amplitudes
- 
- void
- IntensityManager::renormalizeAmps( const NormIntInterface* normInt ){
- 
- m_normInt = normInt;
- m_renormalizeAmps = true;
- }
- 
- void
- IntensityManager::disableRenormalization(){
- 
- m_renormalizeAmps = false;
- }
- */
-

--- a/AmpTools/IUAmpTools/IntensityManager.h
+++ b/AmpTools/IUAmpTools/IntensityManager.h
@@ -423,61 +423,6 @@ public:
    */
   void resetProductionFactors();
   
-  /**
-   * This will cause amplitude manager to renormalize amplitudes <b>in
-   * computations of the intensity only</b>.  Each amplitude will be
-   * multipled by a factor of \f$ 1 / \lang A_i(x) A_i^*(x) \rang \f$
-   * that comes from the normalization integral interface.
-   *
-   * This scaling is useful when fitting data as it results in a trivial
-   * relation between the fit parameters (production amplitudes) and
-   * the number of events associated with each amplitude.
-   *
-   * This feature should be used with caution when coupled with constraints
-   * on the production parameters.  If two amplitudes are constrained
-   * to have the same production coefficient and have the same
-   * scale, turning on renormalization will essentially for the two
-   * amplitudes to have the same number of events in the fit.
-   *
-   * The default behavior is to have renormalization turned off.
-   *
-   * Results of calcAmplitudes or calcIntegrals will remain unchanged.
-   * Note that this is necessary to avoid a circular dependency.
-   *
-   * (Temporarily disabled until NormIntInterface supports renormalization
-   * of amplitudes with free parameters.)
-   *
-   * \param[in] normInt the interface to provide normalization integrals
-   *
-   * \see disableRenormalization
-   * \see ampsAreRenormalized
-   */
-  //  void renormalizeTerms( const NormIntInterface* normInt );
-  
-  /**
-   * This function disables renormalization of amplitudes in the
-   * calculation of the intensity.
-   *
-   * (Temporarily disabled until NormIntInterface supports renormalization
-   * of amplitudes with free parameters.)
-   *
-   * \see renormalizeAmps
-   * \see ampsAreRenormalized
-   */
-  //  void disableRenormalization();
-  
-  /**
-   * This function checks to see whether amplitudes are renormalized
-   * in the intensity calculation.
-   *
-   * \see renormalizeTerms
-   * \see disableRenormalization
-   */
-  bool termsAreRenormalized() const { return m_renormalizeTerms; }
-  
-protected:
-  
-  const NormIntInterface* normInt() const { return m_normInt; }
   
 private:
   
@@ -497,13 +442,8 @@ private:
   
   // a map to hold a set of default production factors
   map< string, complex< double > > m_defaultProdFactor;
-   
-  // a flag to track if we are renormalizing the terms
-  bool m_renormalizeTerms;
-  const NormIntInterface* m_normInt;
   
   vector< AmpParameter > m_termScaleVec;
-    
 };
 
 

--- a/AmpTools/IUAmpTools/LikelihoodCalculator.cc
+++ b/AmpTools/IUAmpTools/LikelihoodCalculator.cc
@@ -132,7 +132,6 @@ SCOREP_USER_REGION_BEGIN( normIntTerm, "normIntTerm", SCOREP_USER_REGION_TYPE_CO
   m_intenManager.prodFactorArray( m_prodFactorArray );
   
   double normTerm = 0;
-  bool renormalize = m_intenManager.termsAreRenormalized();
   
   switch( m_intenManager.type() ){
       
@@ -158,11 +157,6 @@ SCOREP_USER_REGION_BEGIN( normIntTerm, "normIntTerm", SCOREP_USER_REGION_TYPE_CO
           thisTerm -= ( imVa*reVb - reVa*imVb ) * imNI;
           
           if( a != b ) thisTerm *= 2;
-          
-          if( renormalize ){
-            thisTerm /= sqrt( m_ampIntArray[2*a*n+2*a] *
-                              m_ampIntArray[2*b*n+2*b] );
-          }
           
           normTerm += thisTerm;
         }

--- a/AmpTools/IUAmpTools/LikelihoodCalculator.h
+++ b/AmpTools/IUAmpTools/LikelihoodCalculator.h
@@ -119,8 +119,8 @@ private:
   bool m_firstDataCalc;
   
   double* m_prodFactorArray;
-  const GDouble* m_normIntArray;
-  const GDouble* m_ampIntArray;
+  const double* m_normIntArray;
+  const double* m_ampIntArray;
   
   // The flat array of kinematics and amplitudes 
   AmpVecs m_ampVecsSignal;

--- a/AmpTools/IUAmpTools/NormIntInterface.cc
+++ b/AmpTools/IUAmpTools/NormIntInterface.cc
@@ -342,15 +342,7 @@ NormIntInterface::ampInt( string amp, string conjAmp, bool forceUseCache ) const
     << "    Providing original cached value which may be incorrect if\n"
     << "    the parameter has changed since initialization."
     << endl;
-    
-    // problem: this *is* used in a fit if the renormalizeAmps is turned on
-    // and there is a floating parameter in one of the amplitudes
-    // add code here to load up generated MC and hang onto it
-    // print a notice that we're hogging memory in this configuration
-    // for now renormalize is disabled in AmplitudeManager to avoid
-    // confusing the user
   }
-  
   
   if( !hasAmpInt( amp, conjAmp ) ){
     
@@ -437,15 +429,15 @@ NormIntInterface::forceCacheUpdate( bool normIntOnly ) const
 }
 
 void
-NormIntInterface::exportNormIntCache( const string& fileName, bool renormalize) const
+NormIntInterface::exportNormIntCache( const string& fileName ) const
 {
   ofstream out( fileName.c_str() );
   out.precision( 15 );
-  exportNormIntCache( out, renormalize );
+  exportNormIntCache( out );
 }
 
 void
-NormIntInterface::exportNormIntCache( ostream& out, bool renormalize) const
+NormIntInterface::exportNormIntCache( ostream& out ) const
 {
   if( m_emptyNormIntCache || m_emptyAmpIntCache ) forceCacheUpdate();
   
@@ -468,17 +460,7 @@ NormIntInterface::exportNormIntCache( ostream& out, bool renormalize) const
     
       complex< double > value( m_ampIntCache[2*i*n+2*j],
                                m_ampIntCache[2*i*n+2*j+1] );
-      
-      if( renormalize ){
- 
-        // diagonal elements are real so we don't need to deal
-        // with the imaginary part in the renormalization
-        
-        value /= sqrt( m_ampIntCache[2*i*n+2*i] *
-                       m_ampIntCache[2*j*n+2*j] );
-        
-      }
-      
+
       out << value << "\t";
     }
 
@@ -491,19 +473,7 @@ NormIntInterface::exportNormIntCache( ostream& out, bool renormalize) const
       
       complex< double > value( m_normIntCache[2*i*n+2*j],
                                m_normIntCache[2*i*n+2*j+1] );
-      
-      if( renormalize ){
-        
-        // diagonal elements are real so we don't need to deal
-        // with the imaginary part in the renormalization
-        // renormalize by generated so one has efficiency on
-        // the diagonal for the accepted matrix
-        
-        value /= sqrt( m_ampIntCache[2*i*n+2*i] *
-                       m_ampIntCache[2*j*n+2*j] );
-        
-      }
-      
+            
       out << value << "\t";
     }
     

--- a/AmpTools/IUAmpTools/NormIntInterface.cc
+++ b/AmpTools/IUAmpTools/NormIntInterface.cc
@@ -524,24 +524,24 @@ NormIntInterface::initializeCache() {
   // complex conjugation so that memory lookups are easier
   m_cacheSize = 2*n*n;
   
-  m_normIntCache = new GDouble[m_cacheSize];
-  m_ampIntCache = new GDouble[m_cacheSize];
+  m_normIntCache = new double[m_cacheSize];
+  m_ampIntCache = new double[m_cacheSize];
   
-  memset( m_normIntCache, 0, m_cacheSize * sizeof( GDouble ) );
-  memset( m_ampIntCache, 0, m_cacheSize * sizeof( GDouble ) );
+  memset( m_normIntCache, 0, m_cacheSize * sizeof( double ) );
+  memset( m_ampIntCache, 0, m_cacheSize * sizeof( double ) );
 }
 
 void
-NormIntInterface::setAmpIntMatrix( const GDouble* input ) const {
+NormIntInterface::setAmpIntMatrix( const double* input ) const {
   
-  memcpy( m_ampIntCache, input, m_cacheSize * sizeof( GDouble ) );
+  memcpy( m_ampIntCache, input, m_cacheSize * sizeof( double ) );
   m_emptyAmpIntCache = false;
 }
 
 void
-NormIntInterface::setNormIntMatrix( const GDouble* input ) const {
+NormIntInterface::setNormIntMatrix( const double* input ) const {
   
-  memcpy( m_normIntCache, input, m_cacheSize * sizeof( GDouble ) );
+  memcpy( m_normIntCache, input, m_cacheSize * sizeof( double ) );
   m_emptyNormIntCache = false;
 }
 

--- a/AmpTools/IUAmpTools/NormIntInterface.h
+++ b/AmpTools/IUAmpTools/NormIntInterface.h
@@ -89,8 +89,8 @@ public:
   
   // allow direct access to raw data matrix in memory, which is useful
   // for high-speed implementations, but not user friendly
-  const GDouble* ampIntMatrix() const  { return m_ampIntCache;  }
-  const GDouble* normIntMatrix() const { return m_normIntCache; }
+  const double* ampIntMatrix() const  { return m_ampIntCache;  }
+  const double* normIntMatrix() const { return m_normIntCache; }
   
   void setGenEvents( unsigned long int events ) { m_nGenEvents = events; }
   void setAccEvents( double sumWeights ) { m_sumAccWeights = sumWeights; }
@@ -102,8 +102,8 @@ protected:
   const IntensityManager* intenManager() const { return m_pIntenManager; }
   inline int cacheSize() const { return m_cacheSize; }
   
-  void setAmpIntMatrix( const GDouble* input ) const;
-  void setNormIntMatrix( const GDouble* input ) const;
+  void setAmpIntMatrix( const double* input ) const;
+  void setNormIntMatrix( const double* input ) const;
   
 private:
   
@@ -129,8 +129,8 @@ private:
   
   int m_cacheSize;
 
-  mutable GDouble* m_normIntCache;
-  mutable GDouble* m_ampIntCache;
+  mutable double* m_normIntCache;
+  mutable double* m_ampIntCache;
   
   static map< DataReader*, AmpVecs* > m_uniqueDataSets;
 };

--- a/AmpTools/IUAmpTools/NormIntInterface.h
+++ b/AmpTools/IUAmpTools/NormIntInterface.h
@@ -84,8 +84,8 @@ public:
   // override this function
   virtual void forceCacheUpdate( bool normIntOnly = false ) const;
   
-  void exportNormIntCache( const string& fileName, bool renormalize = false ) const;
-  void exportNormIntCache( ostream& output, bool renormalize = false ) const;
+  void exportNormIntCache( const string& fileName ) const;
+  void exportNormIntCache( ostream& output ) const;
   
   // allow direct access to raw data matrix in memory, which is useful
   // for high-speed implementations, but not user friendly

--- a/AmpTools/IUAmpToolsMPI/NormIntInterfaceMPI.cc
+++ b/AmpTools/IUAmpToolsMPI/NormIntInterfaceMPI.cc
@@ -161,24 +161,22 @@ NormIntInterfaceMPI::sumIntegrals( IntType type ) const
   // but we're going to reset the memory in the NormIntInterface
   // at the end of this routine.  This avoids copying.
   
-  GDouble* integrals =
-    const_cast< GDouble* >( type == kNormInt ? normIntMatrix() : ampIntMatrix() );
+  double* integrals =
+    const_cast< double* >( type == kNormInt ? normIntMatrix() : ampIntMatrix() );
   
   // scale up the integrals
   for( int i = 0; i < cacheSize(); ++i ) integrals[i] *= numGenEvents();
   
-  GDouble* result = new GDouble[cacheSize()];
+  double* result = new double[cacheSize()];
   
   // zero out the result array
-  if( m_isLeader ) memset( integrals, 0, cacheSize() * sizeof( GDouble ) );
+  if( m_isLeader ) memset( integrals, 0, cacheSize() * sizeof( double ) );
   
   // at this point, the leader should be holding an array full of zeroes
   // and other nodes will hold integrals for their subsets of data
   
   // sum over all nodes and distribute results to each
-  MPI_Datatype t =
-    ( sizeof( GDouble ) == sizeof( double ) ? MPI_DOUBLE : MPI_FLOAT );  
-  MPI_Allreduce( integrals, result, cacheSize(), t, MPI_SUM, MPI_COMM_WORLD );
+  MPI_Allreduce( integrals, result, cacheSize(), MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD );
 
   // now broadcast the total number of events from the leader to the
   // followers so that they may renormalize the sum properly

--- a/AmpTools/README
+++ b/AmpTools/README
@@ -62,19 +62,7 @@ NOTE: if the free parameter is only a scale parameter
 *that is set by the "scale" command in the config file* then the error
 propagation will be handled correctly in the computation of the intensity.
 
-(3) Capability to renormalize amplitudes to unity is disabled.
-In general, this feature requires a modification of the NormIntInterface 
-to cache the generated MC throughout the fit, as it is needed to recalculate the
-acceptance-corrected amplitude integral to do the normalization.  
-This integral not constant if the amplitude contains free parameters, and
-therefore the generated MC is needed at every fit iteration.  
-(Currently the generated MC is flushed after initialization and 
-only the accepted MC is maintained to save memory.)  If amplitudes
-do not have free parameters, users can experiment with this feature by
-uncommenting the renormalizeAmps method in the AmplitudeManager.
-Do not use for fits with free parameters in amplitudes until a fix is made.
-
-(4) Support for moment/pdf fits: a future version will include the capability
+(3) Support for moment/pdf fits: a future version will include the capability
 to fit data to a sum of moments.  Currently the only supported scheme
 is fitting to multiple coherent sums of amplitudes.  It is possible to obtain
 some equivalent behavior of by fitting using a signle sum and single amplitude

--- a/Makefile.settings
+++ b/Makefile.settings
@@ -52,7 +52,7 @@ endif
 # the user's path
 
 NVCC :=  nvcc
-NVCC_FLAGS := -m64
+NVCC_FLAGS := -m64 $(CXX_DEFINES)
 
 ifndef GPU_ARCH
 GPU_ARCH := sm_70

--- a/Makefile.settings
+++ b/Makefile.settings
@@ -7,6 +7,31 @@ CXX_FLAGS := -O3
 
 #########  END DEFAULT COMPILER SETTINGS
 
+#########  USER BUILD SETTINGS
+# These can be used to control preprocessor definitons to control
+# the compilation of the code.
+
+# Default behavior is to build with double precision stoarge for
+# event-level data like amplitudes and kinematics -- speed and
+# memory use can be optimized by make FP32=1 but at a risk of
+# numerical issues in the minimization algorithm.
+
+ifdef FP32
+CXX_DEFINES := -DAMPTOOLS_GDOUBLE_FP32
+else
+CXX_DEFINES := -DAMPTOOLS_GDOUBLE_FP64
+endif
+
+# This option is here to so that likelihood values for the current
+# version can be compared with those from version 0.13.1 and prior.
+# At some point this build option will be deprecated.
+
+ifdef LEGACY_LN_LIK
+CXX_DEFINES += -DUSE_LEGACY_LN_LIK_SCALING
+endif
+
+CXX_FLAGS += $(CXX_DEFINES)
+#########  END USER BUILD SETTINGS
 
 #########  MPI COMPILER SETTINGS
 # to use MPI, an MPI compiler should be in the user path -- this will be used


### PR DESCRIPTION
This branch allows the user to opt to use single-precision in event-level components of the likelihood calculation.  This is done by enabling clean switching of the GDouble data type between double and float.  If FP32=1 is passed as an argument to make then single-precision (float) is used for event level calculations.

The first term in the computation of -2 ln L has also been reduced by ln N where N is the number of observed events.  This results in -2 ln L growing like N instead of N*ln(N).  (Likelihood values at minimum are difficult to compare with older versions.)