### PR TITLE
use proper number of events for GPU likelihood scaling (not padded by…

### DIFF
--- a/AmpTools/IUAmpTools/AmplitudeManager.cc
+++ b/AmpTools/IUAmpTools/AmplitudeManager.cc
@@ -781,7 +781,7 @@ SCOREP_USER_REGION_BEGIN( calcSumLogIntensity, "calcSumLogIntensity", SCOREP_USE
     // turning it off at compile time.
 
 #ifndef USE_LEGACY_LN_LIK_SCALING
-    gpuProdPars[i] /= sqrt( a.m_iNEvents );
+    gpuProdPars[i] /= sqrt( a.m_iNTrueEvents );
 #endif
   }
   


### PR DESCRIPTION
… factor of 2).  Now get consistent likelihoods between CPU and GPU.