### PR TITLE
corrections to likelihood scaling for MPI

### DIFF
--- a/AmpTools/IUAmpTools/LikelihoodCalculator.cc
+++ b/AmpTools/IUAmpTools/LikelihoodCalculator.cc
@@ -67,6 +67,7 @@ m_firstDataCalc( true ),
 m_firstNormIntCalc( true ),
 m_sumBkgWeights( 0 ),
 m_numBkgEvents( 0 ),
+m_sumDataWeights( 0 ),
 m_numDataEvents( 0 )
 {
   
@@ -222,7 +223,8 @@ SCOREP_USER_REGION_BEGIN( dataTerm, "dataTerm", SCOREP_USER_REGION_TYPE_COMMON )
     m_ampVecsSignal.allocateTerms( m_intenManager, true );
 
     m_numDataEvents = m_ampVecsSignal.m_iNTrueEvents;
-    
+    m_sumDataWeights = m_ampVecsSignal.m_dSumWeights;
+ 
     if( m_ampVecsSignal.m_hasNonUnityWeights && m_hasBackground ){
     
       cout

--- a/AmpTools/IUAmpTools/LikelihoodCalculator.h
+++ b/AmpTools/IUAmpTools/LikelihoodCalculator.h
@@ -99,10 +99,12 @@ protected:
   
   double sumBkgWeights()  const { return m_sumBkgWeights; }
   double numBkgEvents()   const { return m_numBkgEvents;  }
+  double sumDataWeights() const { return m_sumDataWeights;}
   double numDataEvents()  const { return m_numDataEvents; }
   
   void setSumBkgWeights(  double sum ) { m_sumBkgWeights  = sum; }
   void setNumBkgEvents (  double num ) { m_numBkgEvents   = num; }
+  void setSumDataWeights(  double sum ) { m_sumDataWeights = sum; }
   void setNumDataEvents(  double num ) { m_numDataEvents  = num; }
   
 private:
@@ -128,6 +130,7 @@ private:
   
   double m_sumBkgWeights;
   double m_numBkgEvents;
+  double m_sumDataWeights;
   double m_numDataEvents;
 };
 


### PR DESCRIPTION
Add sum of data weights and use to correct likelihood scaling for MPI case where partial sums from each process need re-scaling in the MPI class.