### PR TITLE
add environment variable check to disable the default initial splash screen in report.cc

### DIFF
--- a/AmpTools/IUAmpTools/report.cc
+++ b/AmpTools/IUAmpTools/report.cc
@@ -60,7 +60,7 @@ static int mpiRank_AT = 0;
 
 ostream& report( ReportLevel level ){
 
-  if( !initReportSplash ) initReport();
+  if( !initReportSplash && getenv("AMPTOOLS_DISABLE_SPLASH") == NULL) initReport();
 
 #ifdef USE_MPI
   if( mpiRank_AT > 0 && level < currentLevelMPI )


### PR DESCRIPTION
Checks if the environment variable 'AMPTOOLS_DISABLE_SPLASH' is set. If not set, the initial splash screen will be displayed. If set, the initial splash screen will be disabled.

Resolves #109 