### PR TITLE
Reset errors mrs

### DIFF
--- a/AmpTools/IUAmpTools/AmpToolsInterface.cc
+++ b/AmpTools/IUAmpTools/AmpToolsInterface.cc
@@ -322,9 +322,6 @@ AmpToolsInterface::randomizeProductionPars( float maxFitFraction ){
   
   // shouldn't be callin' unless you're fittin'
   if( m_functionality != kFull ) return;
-
-  // reset parameters (and errors) before randmoizing
-  reinitializePars();
   
   vector< AmplitudeInfo* > amps = m_configurationInfo->amplitudeList();
     
@@ -356,6 +353,9 @@ AmpToolsInterface::randomizeProductionPars( float maxFitFraction ){
     
     m_parameterManager->setProductionParameter( ampName, prodPar );
   }
+  
+  // reset parameter errors after reinitializing parameters
+  minuitMinimizationManager()->resetErrors();
 }
 
 void

--- a/AmpTools/IUAmpTools/AmpToolsInterface.cc
+++ b/AmpTools/IUAmpTools/AmpToolsInterface.cc
@@ -313,7 +313,7 @@ AmpToolsInterface::reinitializePars(){
     m_parameterManager->setAmpParameter( parName, value );
   }
 
-  // reset parameter errors after reinitializing parameters
+  // reset parameter steps after reinitializing parameters
   minuitMinimizationManager()->resetErrors();
 }
 
@@ -354,15 +354,15 @@ AmpToolsInterface::randomizeProductionPars( float maxFitFraction ){
     m_parameterManager->setProductionParameter( ampName, prodPar );
   }
   
-  // reset parameter errors after reinitializing parameters
+  // reset parameter steps after randomizing parameters
   minuitMinimizationManager()->resetErrors();
 }
 
 void
 AmpToolsInterface::randomizeParameter( const string& parName, float min, float max ){
-
+  
   vector<ParameterInfo*> parInfoVec = m_configurationInfo->parameterList();
-
+  
   std::vector<ParameterInfo*>::iterator parItr = parInfoVec.begin();
   for( ; parItr != parInfoVec.end(); ++parItr ){
     
@@ -378,12 +378,15 @@ AmpToolsInterface::randomizeParameter( const string& parName, float min, float m
   if( (**parItr).fixed() ){
     
     report( ERROR, kModule ) << "request to randomize a parameter named " << parName
-         << " that is fixed.  Ignoring this request." << endl;
+    << " that is fixed.  Ignoring this request." << endl;
     return;
   }
   
   double value = min + random( max - min );
   m_parameterManager->setAmpParameter( parName, value );
+  
+  // reset parameter steps after randomizing parameters
+  minuitMinimizationManager()->resetErrors();
 }
 
 void

--- a/AmpTools/MinuitInterface/MinuitMinimizationManager.cc
+++ b/AmpTools/MinuitInterface/MinuitMinimizationManager.cc
@@ -392,6 +392,20 @@ MinuitMinimizationManager::minuitMinimizer()  {
 
 void 
 MinuitMinimizationManager::resetErrors()  {
+  
+  // This call to mnrset appears to reset the internal step
+  // sizes used by MINUIT in minimization.  This may be useful
+  // for sequential fits with randomly seeded parameters.
+  // There are reports that if the parameters change but the
+  // step sizes are not reset, then minimization can start with
+  // an inappropriate step size which leads to failed fits.
+  // After a call to MNRSET it is noticed that the on the MINUIT
+  // display the CURRENT GUESS ERROR printied at the start of the
+  // fit does not change but the STEP SIZE are all all zero
+  // except for one.  The fact that CURRRENT GUESS ERROR is
+  // non-zero appears to have no influence on the subsequent
+  // behavior of the fit.
+
    m_fitter.mnrset(1);
    return;
 }

--- a/AmpTools/MinuitInterface/MinuitMinimizationManager.h
+++ b/AmpTools/MinuitInterface/MinuitMinimizationManager.h
@@ -169,7 +169,7 @@ public:
       m_newFlagFunction = newFlagFunction;
    }
    
-   // reset parameter errors
+   // reset parameter step sizes
    void resetErrors();
 
    // the "fcn" that URMinuit needs


### PR DESCRIPTION
This inserts calls to MNRSET that will reset the internal step sizes in MINUIT after parameters have been changed.  This is useful for sequential fits where one wants to randomly seed parameters.  Each new fit will begin with MINUIT re-determining the optimal step size.