### PR TITLE
Fix logic in disabling splash screen

### DIFF
--- a/AmpTools/IUAmpTools/report.cc
+++ b/AmpTools/IUAmpTools/report.cc
@@ -138,7 +138,7 @@ void initReport(){
 
 #ifndef __ACLIC__
   
-  if( getenv("AMPTOOLS_DISABLE_SPLASH") != NULL ){
+  if( getenv("AMPTOOLS_DISABLE_SPLASH") == NULL ){
     
     cout << "   "; printLine();
     cout << setw(22) << right << "|        ^         " << setw(46) << right <<  "|" << endl;


### PR DESCRIPTION
To disable the splash screen, we check if the environment variable $AMPTOOLS_DISABLE_SPLASH is _not_ NULL (we opt out of the splash screen). A previous refactoring accidentally reversed the logic, displaying the splash screen if $AMPTOOLS_DISABLE_SPLASH != NULL, which is the opposite of what we want. This PR fixes it.