### PR TITLE
Debug par scan

### DIFF
--- a/AmpTools/IUAmpTools/AmpParameter.cc
+++ b/AmpTools/IUAmpTools/AmpParameter.cc
@@ -130,6 +130,8 @@ AmpParameter::operator==( const AmpParameter& otherPar ) const {
 
 void 
 AmpParameter::setExternalValue( const double* ptr ){
+
+  report( DEBUG, kModule ) << "Setting " << m_name << " by reference to " << *ptr << endl;
   
   m_valPtr = ptr;
   m_hasExternalPtr = true;
@@ -137,6 +139,8 @@ AmpParameter::setExternalValue( const double* ptr ){
 
 void
 AmpParameter::setValue( double val ){
+  
+  report( DEBUG, kModule ) << "Setting " << m_name << " by value to " << val << endl;
   
   m_defaultValue = val;
   m_valPtr = &m_defaultValue;

--- a/AmpTools/IUAmpTools/AmpToolsInterface.h
+++ b/AmpTools/IUAmpTools/AmpToolsInterface.h
@@ -71,14 +71,14 @@ using namespace std;
  * member functions.
  *
  * To reconfigure the AmpToolsInterface class with a new ConfigurationInfo
- * object, use the resetConfigurationInfo method.  This will recreate 
+ * object, use the resetConfigurationInfo method.  This will recreate
  * all the major classes of IUAmpTools.
  *
  * Methods such as loadEvents, processEvents, decayAmplitude, and
  * intensity are provided to perform calculations manually, which can be
  * useful when generating Monte Carlo, for example.
  *
- * For MPI implementations, use the AmpToolsInterfaceMPI class, which 
+ * For MPI implementations, use the AmpToolsInterfaceMPI class, which
  * is derived from this class.
  *
  * \ingroup IUAmpTools
@@ -86,11 +86,11 @@ using namespace std;
 
 
 class AmpToolsInterface{
-
-  public:
-
+  
+public:
+  
   enum FunctionalityFlag { kFull, kMCGeneration, kPlotGeneration };
-
+  
   AmpToolsInterface( FunctionalityFlag flag = kFull );
   
   /** Constructor.
@@ -100,147 +100,147 @@ class AmpToolsInterface{
    * classes are set up and configured based on the information contained in this
    * ConfigurationInfo object.
    */
-
-    AmpToolsInterface( ConfigurationInfo* cfgInfo, FunctionalityFlag flag = kFull );
-
+  
+  AmpToolsInterface( ConfigurationInfo* cfgInfo, FunctionalityFlag flag = kFull );
+  
   /** Destructor.
    */
-
-    virtual ~AmpToolsInterface() { clear(); }
-
+  
+  virtual ~AmpToolsInterface() { clear(); }
+  
   /** Static function to register a user Amplitude class.  For example,
    *  to register a user-defined BreitWigner amplitude, one would use:
    *     AmpToolsInterface::registerAmplitude(BreitWigner());
    */
-
-    static void registerAmplitude( const Amplitude& defaultAmplitude);
-
+  
+  static void registerAmplitude( const Amplitude& defaultAmplitude);
+  
   /** Static function to register a user Neg2LnLikContrib class.  For example,
    *  to register a user-defined phaseshift Neg2LnLikContrib, one would use:
    *     AmpToolsInterface::registerAmplitude(phaseshift());
    */
-
-    static void registerNeg2LnLikContrib( const Neg2LnLikContrib& defaulNeg2LnLikContrib);
-
+  
+  static void registerNeg2LnLikContrib( const Neg2LnLikContrib& defaulNeg2LnLikContrib);
+  
   /** Static function to register a user DataReader class.  For example,
    *  to register a user-defined CLEODataReader, one would use:
    *     AmpToolsInterface::registerDataReader(CLEODataReader());
    */
-
-    static void registerDataReader( const DataReader& defaultDataReader);
-
+  
+  static void registerDataReader( const DataReader& defaultDataReader);
+  
   static void setRandomSeed( unsigned int seed ) { m_randomSeed = seed; }
   
   /** Use this method to re-initialize all IUAmpTools classes based on information
    *  in a new or modified ConfigurationInfo object.
    */
-
-    void resetConfigurationInfo(ConfigurationInfo* cfgInfo);
-
-
+  
+  void resetConfigurationInfo(ConfigurationInfo* cfgInfo);
+  
+  
   /** Return the ConfigurationInfo object stored in this class.
    *  After modifying this object, one can use the resetConfigurationInfo method
    *  to re-initialize the IUAmpTools classes.
    */
-
-    ConfigurationInfo* configurationInfo() const
-                                 { return m_configurationInfo; }
-
-
+  
+  ConfigurationInfo* configurationInfo() const
+  { return m_configurationInfo; }
+  
+  
   /** Pointer to the MinuitMinimizationManager.
    *  Use the methods in MinuitMinimizationManager to do fits.
    */
-
-    MinuitMinimizationManager* minuitMinimizationManager() const
-                                 { return m_minuitMinimizationManager; }
-
+  
+  MinuitMinimizationManager* minuitMinimizationManager() const
+  { return m_minuitMinimizationManager; }
+  
   /** Pointer to the ParameterManager.
    *  Use this to get fit results, for example.
    */
-
-    ParameterManager*          parameterManager() const
-                                 { return m_parameterManager;}
-
-
+  
+  ParameterManager*          parameterManager() const
+  { return m_parameterManager;}
+  
+  
   /** Pointer to an IntensityManager.  There is one for each defined reaction.
    *  (Most applications will not likely need to access these.)
    */
-
-    IntensityManager*     intensityManager     (const string& reactionName) const;
-
-
+  
+  IntensityManager*     intensityManager     (const string& reactionName) const;
+  
+  
   /** Returns a pointer to a DataReader (for data).
    *  There is one for each reaction.
    */
-
-    DataReader*           dataReader           (const string& reactionName) const;
-
+  
+  DataReader*           dataReader           (const string& reactionName) const;
+  
   /** Returns a pointer to a DataReader (for background).
    *  There is one for each reaction.
    */
   
-    DataReader*           bkgndReader           (const string& reactionName) const;
-
+  DataReader*           bkgndReader           (const string& reactionName) const;
+  
   /** Returns a pointer to a DataReader (for accepted Monte Carlo).
    *  There is one for each reaction.
    */
-
-    DataReader*           accMCReader          (const string& reactionName) const;
-
-
+  
+  DataReader*           accMCReader          (const string& reactionName) const;
+  
+  
   /** Returns a pointer to a DataReader (for generated Monte Carlo).
    *  There is one for each reaction.
    */
-
-    DataReader*           genMCReader          (const string& reactionName) const;
-
-
+  
+  DataReader*           genMCReader          (const string& reactionName) const;
+  
+  
   /** Pointer to a NormIntInterface (one per reaction).
    *  Use this to access normalization integrals.
    */
-
-    NormIntInterface*     normIntInterface     (const string& reactionName) const;
-
+  
+  NormIntInterface*     normIntInterface     (const string& reactionName) const;
+  
   /** Pointer to a FitResults class.
    * Use this to access information that is stored after finalizeFit() is called.
    */
   
-    const FitResults* fitResults() const { return m_fitResults; }
+  const FitResults* fitResults() const { return m_fitResults; }
   
-
+  
   /** Pointer to a Likelihood calculator (one per reaction).
    *  (Most applications will not likely need to access these.)
-   *  One can also access the likelihood value through the likelihood methods 
+   *  One can also access the likelihood value through the likelihood methods
    *  below.
    *
    *  \see likelihood
    */
-
-    LikelihoodCalculator* likelihoodCalculator (const string& reactionName) const;
-
-
+  
+  LikelihoodCalculator* likelihoodCalculator (const string& reactionName) const;
+  
+  
   /** Return the total -2ln(likelihood) (summed over all reactions) using
    *  the parameters stored in the ParameterManager and the amplitudes
    *  in the AmplitudeManagers.  Call this before performing a fit to get
-   *  the pre-fit likelihood value and call it after the fit to get the 
+   *  the pre-fit likelihood value and call it after the fit to get the
    *  post-fit value.
    */
-
-    double likelihood() const;
-
+  
+  double likelihood() const;
+  
   /** Return the -2ln(likelihood) associated with a particular reaction.
    */
-
-    double likelihood(const string& reactionName) const;
-
-  /** Reinitialize production and amplitude parameters to the values from 
+  
+  double likelihood(const string& reactionName) const;
+  
+  /** Reinitialize production and amplitude parameters to the values from
    * ConfigurationInfo.  This is useful for repeated fits where most parameters
-   * should be seeded with the same values, for example in a likelihood 
+   * should be seeded with the same values, for example in a likelihood
    * scan over a single parameter.
    */
-
+  
   void reinitializePars( );
-
+  
   /** This function will randomly set the production parameters in
    * the likelihood calculator.  It is useful when searching for multiple
    * ambiguous solutions.  Production parameters will be set such that
@@ -248,7 +248,7 @@ class AmpToolsInterface{
    * by the optional argument.  The phase will be set randomly between
    * zero and 2 pi.
    */
-
+  
   void randomizeProductionPars( float maxFitFraction = 1 );
   
   /** This function will fill the value of a parameter named parName with
@@ -259,15 +259,15 @@ class AmpToolsInterface{
    */
   
   void randomizeParameter( const string& parName, float min = 0, float max = 1 );
-
+  
   /** Print final fit results to a file.  The tag can be used to
    *  generate a unique name in the case that multiple results are
    *  written for a singele fit job.
    */
-
-    virtual void finalizeFit( const string& tag = "" );
-
-
+  
+  virtual void finalizeFit( const string& tag = "" );
+  
+  
   /** For manual calculations:  clear all events and calculations.
    *  Call this before loading events from a new reaction or to start
    *  new calcuations.
@@ -278,9 +278,9 @@ class AmpToolsInterface{
    *  \see loadEvents
    *  \see processEvents
    */
-
-    void clearEvents(unsigned int iDataSet = 0);
-
+  
+  void clearEvents(unsigned int iDataSet = 0);
+  
   /** For manual calculations:  load event kinematics from a DataReader.
    *  Call this after clearing old events (clearEvents) and before
    *  performing calculations (processEvents).
@@ -290,10 +290,10 @@ class AmpToolsInterface{
    *  \see clearEvents
    *  \see processEvents
    */
-
-    void loadEvents(DataReader* dataReader,
-                    unsigned int iDataSet = 0);
-
+  
+  void loadEvents(DataReader* dataReader,
+                  unsigned int iDataSet = 0);
+  
   /** For manual calculations:  load kinematics one event at a time.
    *  Clear old events (clearEvents) before loading a new set of events.
    *  Load all events before performing calculations (processEvents).
@@ -306,10 +306,10 @@ class AmpToolsInterface{
    *  \see clearEvents
    *  \see processEvents
    */
-
-    void loadEvent(Kinematics* kin, int iEvent = 0, int nEventsTotal = 1,
-                    unsigned int iDataSet = 0);
-
+  
+  void loadEvent(Kinematics* kin, int iEvent = 0, int nEventsTotal = 1,
+                 unsigned int iDataSet = 0);
+  
   /** For manual calculations:  perform all calculations on the loaded events.
    *  Load all events (loadEvent or loadEvents) before performing calculations.
    *  Returns the maximum intensity.
@@ -321,11 +321,11 @@ class AmpToolsInterface{
    *  \see loadEvent
    *  \see loadEvents
    */
-
-    double processEvents(string reactionName,
-                    unsigned int iDataSet = 0);
-
-
+  
+  double processEvents(string reactionName,
+                       unsigned int iDataSet = 0);
+  
+  
   /** The number of events that have been loaded for manual calculations.
    *
    *  \see clearEvents
@@ -333,11 +333,11 @@ class AmpToolsInterface{
    *  \see loadEvents
    *  \see processEvents
    */
-
-    int numEvents(unsigned int iDataSet = 0) const;
-    double sumWeights(unsigned int iDataSet = 0) const;
-
-
+  
+  int numEvents(unsigned int iDataSet = 0) const;
+  double sumWeights(unsigned int iDataSet = 0) const;
+  
+  
   /** Retrieve the intensity calculated for the specified event.
    *  This requires a prior call to processEvents.
    *
@@ -346,12 +346,12 @@ class AmpToolsInterface{
    *  \see loadEvents
    *  \see processEvents
    */
-
-    double intensity(int iEvent,
-                    unsigned int iDataSet = 0) const;
-
-
-  /** Perform an alternate calculation of the intensity.  If there are no 
+  
+  double intensity(int iEvent,
+                   unsigned int iDataSet = 0) const;
+  
+  
+  /** Perform an alternate calculation of the intensity.  If there are no
    *  precision problems, this should be identical to the value returned
    *  by the intensity method.
    *  This requires a prior call to processEvents.
@@ -361,11 +361,11 @@ class AmpToolsInterface{
    *  \see loadEvents
    *  \see processEvents
    */
-
-    double alternateIntensity(int iEvent,
-                    unsigned int iDataSet = 0) const;
-
-
+  
+  double alternateIntensity(int iEvent,
+                            unsigned int iDataSet = 0) const;
+  
+  
   /** Retrieve a decay amplitude calculated for the specified event.
    *  This requires a prior call to processEvents.
    *
@@ -377,11 +377,11 @@ class AmpToolsInterface{
    *  \see loadEvents
    *  \see processEvents
    */
-
-    complex<double> decayAmplitude (int iEvent, string ampName,
-                    unsigned int iDataSet = 0) const;
-
-
+  
+  complex<double> decayAmplitude (int iEvent, string ampName,
+                                  unsigned int iDataSet = 0) const;
+  
+  
   /** Retrieve the production amplitude associated with a given amplitude.
    *  Recall that all amplitudes are defined as
    *    (production amplitude)  x  (decay amplitude)
@@ -394,11 +394,11 @@ class AmpToolsInterface{
    *
    * \see AmplitudeManager::getScale
    */
-
-    complex<double> scaledProductionAmplitude (string ampName,
-                                               unsigned int iDataSet = 0) const;
-
-
+  
+  complex<double> scaledProductionAmplitude (string ampName,
+                                             unsigned int iDataSet = 0) const;
+  
+  
   /** Return the kinematics for a specified event as it was loaded using
    *  the loadEvent or loadEvents method.
    *
@@ -407,83 +407,91 @@ class AmpToolsInterface{
    *  \see loadEvents
    *  \see processEvents
    */
-
-    Kinematics* kinematics(int iEvent,
-                           unsigned int iDataSet = 0);
-
-
-  /** For debugging and diagnostics:  print event kinematics to the screen in 
+  
+  Kinematics* kinematics(int iEvent,
+                         unsigned int iDataSet = 0);
+  
+  
+  /** For debugging and diagnostics:  print event kinematics to the screen in
    *  a readable format.
    */
-
-    void printKinematics   (string reactionName, Kinematics* kin) const;
-
-
-  /** For debugging and diagnostics:  print amplitude values to the screen in 
+  
+  void printKinematics   (string reactionName, Kinematics* kin) const;
+  
+  
+  /** For debugging and diagnostics:  print amplitude values to the screen in
    *  a readable format.
    */
-
-    void printAmplitudes   (string reactionName, Kinematics* kin) const;
-
+  
+  void printAmplitudes   (string reactionName, Kinematics* kin) const;
+  
   /** For debugging and diagnostics:  print an intensity to the screen in
    *  a readable format.
    */
-
-    void printIntensity    (string reactionName, Kinematics* kin) const;
-
+  
+  void printIntensity    (string reactionName, Kinematics* kin) const;
+  
   /** For debugging and diagnostics:  print event details to the screen in
    *  a readable format.
    */
-
-    void printEventDetails (string reactionName, Kinematics* kin) const;
-
-
-  protected:
   
-    AmpToolsInterface( const AmpToolsInterface& ati );
-    AmpToolsInterface& operator=( AmpToolsInterface& ati );
-
-    FunctionalityFlag m_functionality;
+  void printEventDetails (string reactionName, Kinematics* kin) const;
   
-    void clear();
-
-    ConfigurationInfo*          m_configurationInfo;
-    MinuitMinimizationManager*  m_minuitMinimizationManager;
-    ParameterManager*           m_parameterManager;
-
-    vector<IntensityManager*>  m_intensityManagers;
-
-
-    map<string,DataReader*> m_dataReaderMap;
-    map<string,DataReader*> m_bkgndReaderMap;
-    map<string,DataReader*> m_genMCReaderMap;
-    map<string,DataReader*> m_accMCReaderMap;
+  /**
+   * This allows the user to control how this flag is set on all the IntensityManagers in the fit
+   */
+  void forceUserVarRecalculation( bool state );
   
-    // use a set here because entries can't be duplicated and
-    // this makes it easy to avoid a double-delete at cleanup time
-    set<DataReader*> m_uniqueDataSets;
-
-    map<string,NormIntInterface*>     m_normIntMap;
-    map<string,LikelihoodCalculator*> m_likCalcMap;
-
-    static vector<Amplitude*>  m_userAmplitudes;
-    static vector<Neg2LnLikContrib*>  m_userNeg2LnLikContribs;
-    static vector<DataReader*> m_userDataReaders;
+protected:
+  
+  AmpToolsInterface( const AmpToolsInterface& ati );
+  AmpToolsInterface& operator=( AmpToolsInterface& ati );
+  
+  FunctionalityFlag m_functionality;
+  
+  void clear();
+  
+  ConfigurationInfo*          m_configurationInfo;
+  MinuitMinimizationManager*  m_minuitMinimizationManager;
+  ParameterManager*           m_parameterManager;
+  
+  vector<IntensityManager*>  m_intensityManagers;
+  
+  
+  map<string,DataReader*> m_dataReaderMap;
+  map<string,DataReader*> m_bkgndReaderMap;
+  map<string,DataReader*> m_genMCReaderMap;
+  map<string,DataReader*> m_accMCReaderMap;
+  
+  // use a set here because entries can't be duplicated and
+  // this makes it easy to avoid a double-delete at cleanup time
+  set<DataReader*> m_uniqueDataSets;
+  
+  map<string,NormIntInterface*>     m_normIntMap;
+  map<string,LikelihoodCalculator*> m_likCalcMap;
+  
+  static vector<Amplitude*>  m_userAmplitudes;
+  static vector<Neg2LnLikContrib*>  m_userNeg2LnLikContribs;
+  static vector<DataReader*> m_userDataReaders;
   
   static unsigned int m_randomSeed;
   
   // these variables are used in cases where the AmpToolsInterface
   // must provide a place to load the data -- during normal
   // fitting the data are held by the likelihood calculator
-
-    static const int MAXAMPVECS = 50;
-    AmpVecs m_ampVecs[MAXAMPVECS];
-    string  m_ampVecsReactionName[MAXAMPVECS];
-   
-    FitResults* m_fitResults;
   
-    float random( float randMax );
-
+  static const int MAXAMPVECS = 50;
+  AmpVecs m_ampVecs[MAXAMPVECS];
+  string  m_ampVecsReactionName[MAXAMPVECS];
+  
+  FitResults* m_fitResults;
+  
+  float random( float randMax ) const;
+  
+private:
+  
+  void invalidateAmps();
+  
   static const char* kModule;
 };
 

--- a/AmpTools/IUAmpTools/Amplitude.cc
+++ b/AmpTools/IUAmpTools/Amplitude.cc
@@ -413,6 +413,9 @@ SCOREP_USER_REGION_BEGIN( updatePar, "updatePar", SCOREP_USER_REGION_TYPE_COMMON
     
     if( (**parItr).name().compare( name ) == 0 ){
       
+      report( DEBUG, kModule ) << "Calling updatePar for " << this->name() << " with "
+      << (**parItr).name() << " as the argument." << endl;
+      
       // The const_cast is a little bit undesirable here.  It can be removed
       // at the expensive of requiring the user to declare all member data in
       // the Amplitude class that is updated on a parameter update "mutable."

--- a/AmpTools/IUAmpTools/AmplitudeManager.h
+++ b/AmpTools/IUAmpTools/AmplitudeManager.h
@@ -426,40 +426,7 @@ public:
    */
   void updatePar( const string& parName ) const;
   
-  /**
-   * This function can be used to set a flag to optimize subsequent
-   * calls to calcTerms in the case that amplitudes have free parameters.
-   * It uses functionality in the updatePar function to only force a
-   * recalculation of the amplitude for a particular AmpVecs class if
-   * one of the AmpParameters for that amplitude has changed since
-   * the last calculation.  This should signficiantly enhance the speed
-   * for fits with parameters floating in amplitudes, since there will
-   * only be an expensive recomputation when MINUIT changes the parameter.
-   *
-   * \param[in] flag set to true to enable the optimization
-   */
-  void setOptimizeParIteration( bool flag ) { m_optimizeParIteration = flag; }
   
-  /**
-   * This function will allow the AmplitudeManager to clear four vectors
-   * from memory if all amplitudes can be calculated from user variables.
-   *
-   * \param[in] flag set to true to enable the optimization
-   */
-  void setFlushFourVecsIfPossible( bool flag ) { m_flushFourVecsIfPossible = flag; }
-  
-  /**
-   * If set to true, this flag will force the recalculation of the user
-   * data every time that calcTerms is called.  This is needed in cases
-   * where one reuses a common memory block multiple times with different
-   * kinematics, like what happens in MC generation.
-   *
-   * \param[in] flag set to true to enable the optimization
-   */
-  void setForceUserVarRecalculation( bool flag ) {
-    m_forceUserVarRecalculation = flag;
-    m_flushFourVecsIfPossible = false;
-  }
 
 
 private:
@@ -496,12 +463,6 @@ private:
   // vector to short-cut recomputation of terms with all fixed factors
   vector< bool > m_vbIsAmpFixed;
     
-  // some internal members to optimize amplitude recalculation
-  bool m_needsUserVarsOnly;
-  bool m_optimizeParIteration;
-  bool m_flushFourVecsIfPossible;
-  bool m_forceUserVarRecalculation;
-  
   mutable map< const Amplitude*, int > m_ampIteration;
   mutable map< AmpVecs*, map< const Amplitude*, int > > m_dataAmpIteration;
   mutable map< string, unsigned long long > m_staticUserVarsOffset;

--- a/AmpTools/IUAmpTools/FitResults.cc
+++ b/AmpTools/IUAmpTools/FitResults.cc
@@ -78,9 +78,9 @@ m_isValid( true ){
 #endif
 
 
-FitResults::FitResults( const string& inFile ) :
+FitResults::FitResults( const string& inFile, bool muteWarning ) :
 m_createdFromFile( true ),
-m_warnedAboutFreeParams( false ),
+m_warnedAboutFreeParams( muteWarning ),
 m_isValid( false ){
   
   loadResults( inFile );

--- a/AmpTools/IUAmpTools/FitResults.h
+++ b/AmpTools/IUAmpTools/FitResults.h
@@ -110,7 +110,7 @@ public:
    *
    * \param[in] inFile the name of the input file
    */
-  FitResults( const string& inFile );
+  FitResults( const string& inFile, bool muteWarning = false );
   
   /**
    * The destructor.

--- a/AmpTools/IUAmpTools/IntensityManager.cc
+++ b/AmpTools/IUAmpTools/IntensityManager.cc
@@ -58,7 +58,11 @@ const char* IntensityManager::kModule = "IntensityManager";
 
 IntensityManager::IntensityManager( const vector< string >& reaction,
                                    const string& reactionName) :
-m_reactionName(reactionName)
+m_reactionName( reactionName) ,
+m_needsUserVarsOnly( true ),
+m_optimizeParIteration( false ),
+m_flushFourVecsIfPossible( false ),
+m_forceUserVarRecalculation( false )
 {
 
 }

--- a/AmpTools/IUAmpTools/IntensityManager.h
+++ b/AmpTools/IUAmpTools/IntensityManager.h
@@ -423,6 +423,48 @@ public:
    */
   void resetProductionFactors();
   
+  /**
+   * This function can be used to set a flag to optimize subsequent
+   * calls to calcTerms in the case that amplitudes have free parameters.
+   * It uses functionality in the updatePar function to only force a
+   * recalculation of the amplitude for a particular AmpVecs class if
+   * one of the AmpParameters for that amplitude has changed since
+   * the last calculation.  This should signficiantly enhance the speed
+   * for fits with parameters floating in amplitudes, since there will
+   * only be an expensive recomputation when MINUIT changes the parameter.
+   *
+   * \param[in] flag set to true to enable the optimization
+   */
+  void setOptimizeParIteration( bool flag ) { m_optimizeParIteration = flag; }
+  
+  /**
+   * This function will allow the AmplitudeManager to clear four vectors
+   * from memory if all amplitudes can be calculated from user variables.
+   *
+   * \param[in] flag set to true to enable the optimization
+   */
+  void setFlushFourVecsIfPossible( bool flag ) { m_flushFourVecsIfPossible = flag; }
+  
+  /**
+   * If set to true, this flag will force the recalculation of the user
+   * data every time that calcTerms is called.  This is needed in cases
+   * where one reuses a common memory block multiple times with different
+   * kinematics, like what happens in MC generation.
+   *
+   * \param[in] flag set to true to enable the optimization
+   */
+  void setForceUserVarRecalculation( bool flag ) {
+    m_forceUserVarRecalculation = flag;
+    m_flushFourVecsIfPossible = false;
+  }
+  
+protected:
+  
+  // some internal members to optimize term recalculation
+  bool m_needsUserVarsOnly;
+  bool m_optimizeParIteration;
+  bool m_flushFourVecsIfPossible;
+  bool m_forceUserVarRecalculation;
   
 private:
   

--- a/AmpTools/IUAmpTools/LikelihoodCalculator.cc
+++ b/AmpTools/IUAmpTools/LikelihoodCalculator.cc
@@ -97,7 +97,10 @@ LikelihoodCalculator::operator()(){
   // integral sums -- this provides parallel implementations with the
   // methods they need to compute these terms individually
   
-  return -2 * ( dataTerm() - normIntTerm() );
+  double neg2LnLik =  -2 * ( dataTerm() - normIntTerm() );
+  report( DEBUG, kModule ) << "Returning -2 ln( L ) = " << neg2LnLik << endl;
+  
+  return neg2LnLik;
 }
 
 double
@@ -298,5 +301,16 @@ SCOREP_USER_REGION_BEGIN( dataTerm, "dataTerm", SCOREP_USER_REGION_TYPE_COMMON )
 SCOREP_USER_REGION_END( dataTerm )
 #endif
   
+  report( DEBUG, kModule ) << "Sum_data of ln( I ):  " << sumLnI << endl;
+  
   return sumLnI;
+}
+
+void
+LikelihoodCalculator::invalidateTerms(){
+  
+  m_ampVecsSignal.m_termsValid = false;
+  m_ampVecsSignal.m_integralValid = false;
+  m_ampVecsBkgnd.m_termsValid = false;
+  m_ampVecsBkgnd.m_integralValid = false;
 }

--- a/AmpTools/IUAmpTools/LikelihoodCalculator.h
+++ b/AmpTools/IUAmpTools/LikelihoodCalculator.h
@@ -86,6 +86,8 @@ public:
   
   virtual double numSignalEvents();
   
+  void invalidateTerms();
+  
 protected:
   
   // helper functions -- also useful for pulling parts of the

--- a/AmpTools/IUAmpTools/NormIntInterface.cc
+++ b/AmpTools/IUAmpTools/NormIntInterface.cc
@@ -552,6 +552,8 @@ NormIntInterface::setNormIntMatrix( const double* input ) const {
   m_emptyNormIntCache = false;
 }
 
+
+#ifndef __ACLIC__
 void
 NormIntInterface::invalidateTerms(){
   
@@ -562,7 +564,6 @@ NormIntInterface::invalidateTerms(){
   m_genMCVecs.m_integralValid = false;
 }
 
-#ifndef __ACLIC__
 map< DataReader*, AmpVecs* > NormIntInterface::m_uniqueDataSets;
 #endif
 

--- a/AmpTools/IUAmpTools/NormIntInterface.h
+++ b/AmpTools/IUAmpTools/NormIntInterface.h
@@ -88,6 +88,8 @@ public:
   // needs to be virtual so parallel implementations can properly
   // override this function
   virtual void forceCacheUpdate( bool normIntOnly = false ) const;
+  
+  void invalidateTerms();
 
 #endif
   
@@ -101,8 +103,6 @@ public:
   
   void setGenEvents( unsigned long int events ) { m_nGenEvents = events; }
   void setAccEvents( double sumWeights ) { m_sumAccWeights = sumWeights; }
-  
-  void invalidateTerms();
   
 protected:
   

--- a/AmpTools/IUAmpTools/NormIntInterface.h
+++ b/AmpTools/IUAmpTools/NormIntInterface.h
@@ -102,6 +102,8 @@ public:
   void setGenEvents( unsigned long int events ) { m_nGenEvents = events; }
   void setAccEvents( double sumWeights ) { m_sumAccWeights = sumWeights; }
   
+  void invalidateTerms();
+  
 protected:
   
   // protected helper functions for parallel implementations

--- a/AmpTools/MinuitInterface/MinuitMinimizationManager.cc
+++ b/AmpTools/MinuitInterface/MinuitMinimizationManager.cc
@@ -209,6 +209,8 @@ MinuitMinimizationManager::migradMinimization() {
   timeval tStart,tStop,tSpan;
   double dTime;
   
+  report( DEBUG, kModule ) << "Running migradMinimization()..." << endl;
+  
   gettimeofday( &(tStart), NULL );
   
    int dummyI;

--- a/AmpTools/MinuitInterface/MinuitParameterManager.cc
+++ b/AmpTools/MinuitInterface/MinuitParameterManager.cc
@@ -118,6 +118,8 @@ MinuitParameterManager::synchronizeMinuit()
   
   m_numFloatingPars = 0;
   
+  report( DEBUG, kModule ) << "Synchronizing parameters with MINUIT." << endl;
+  
   // check that minuit has each parameter's status correct
   for ( ParamIter parameter = begin(); parameter != end(); ++parameter ) 
   {
@@ -176,15 +178,17 @@ MinuitParameterManager::synchronizeMinuit()
         theMinimizer.mnexcm( limCommand, commandParameters, 3,  status );
       }
     }
-    
   } // end of loop over parameters
+  
+  report( DEBUG, kModule ) << "Finished synchronizing -- " << m_numFloatingPars
+                           << " parameters are floating in the fit." << endl;
 }
 
 bool
 MinuitParameterManager::registerParameter( MinuitParameter* newParameter ) 
 {
 
-   
+  report( DEBUG, kModule ) << "Registering new parameter:  " << newParameter->name() << endl;
    // the minuit user Id for this parameter
    unsigned int newParameterMinuitId = size(); 
    ++newParameterMinuitId;

--- a/AmpTools/MinuitInterface/Parameter.cc
+++ b/AmpTools/MinuitInterface/Parameter.cc
@@ -37,8 +37,11 @@
 #include <string>
 
 #include "MinuitInterface/Parameter.h"
+#include "IUAmpTools/report.h"
 
 using namespace std;
+
+const char* Parameter::kModule = "Parameter";
 
 Parameter::Parameter(  const string& name, double initialValue, double initialError ) :
 m_name( name ),
@@ -52,6 +55,9 @@ void
 Parameter::setValue( double newValue, bool doNotify ) {
 
   if( m_value != newValue ){
+    
+    report( DEBUG, kModule ) << "Parameter " << m_name <<
+    " value changed;  doNotify = " << doNotify << endl;
 
     // In practice the comparison above could probably "safely" be
     // done within some tolerance, but set to exact comparison for now.

--- a/AmpTools/MinuitInterface/Parameter.h
+++ b/AmpTools/MinuitInterface/Parameter.h
@@ -66,5 +66,7 @@ private:
   std::string m_name;
   double m_value;
   double m_error;
+  
+  static const char* kModule;
 };
 #endif


### PR DESCRIPTION
This adds many debugging statements in classes.  The only functional change is the introduction of a member function to the AmpToolsInterface that lets the user set the termsValid and integralValid flags of the relevant AmpVecs objects to false.  This will trigger the recalculation of userVars in some cases.  The ability to do this is important in cases where one wants to scan parameters.