### PR TITLE
Memory fixes

### DIFF
--- a/AmpTools/GPUManager/GPUManager.cc
+++ b/AmpTools/GPUManager/GPUManager.cc
@@ -640,15 +640,19 @@ void GPUManager::clearAll()
   if(m_pfDevAmps)
     cudaFree(m_pfDevAmps);
   m_pfDevAmps=0;
-  
+
   if(m_pfDevVVStar)
     cudaFree(m_pfDevVVStar);
   m_pfDevVVStar=0;
-  
+
+  if(m_pdDevNICalc)
+    cudaFree(m_pdDevNICalc);
+  m_pdDevNICalc=0;
+
   if(m_pfDevWeights)
     cudaFree(m_pfDevWeights);
   m_pfDevWeights=0;
-  
+
   if(m_pdDevRes)
     cudaFree(m_pdDevRes);
   m_pdDevRes=0;

--- a/AmpTools/GPUManager/GPUManager.h
+++ b/AmpTools/GPUManager/GPUManager.h
@@ -132,8 +132,6 @@ private:
   unsigned int m_iNICalcSize;
   
   //Host Arrays
-  GDouble* m_pcCalcAmp;
-  
   GDouble* m_pfVVStar;
   double* m_pdRes;
   

--- a/AmpTools/IUAmpTools/AmpToolsInterface.cc
+++ b/AmpTools/IUAmpTools/AmpToolsInterface.cc
@@ -507,8 +507,6 @@ AmpToolsInterface::registerDataReader( const DataReader& dataReader){
   
 }
 
-
-
 void
 AmpToolsInterface::clear(){
   
@@ -550,9 +548,13 @@ AmpToolsInterface::clear(){
     m_ampVecs[i].deallocAmpVecs();
     m_ampVecsReactionName[i] = "";
   }
+
+  // NOTE:  order matters here -- the ParameterManagers need to be deleted
+  // before the MinuitMinimizationManager as some types of parameter constraints
+  // like GaussianBound, need to detach themselves from the minimizaiton manager
   
-  if (minuitMinimizationManager()) delete minuitMinimizationManager();
   if (parameterManager()) delete parameterManager();
+  if (minuitMinimizationManager()) delete minuitMinimizationManager();
   if (fitResults()) delete fitResults();
 }
 

--- a/AmpTools/IUAmpTools/AmpVecs.h
+++ b/AmpTools/IUAmpTools/AmpVecs.h
@@ -307,9 +307,16 @@ struct AmpVecs
    * data containers specified by the argument.
    */
   void claimDataOwnership( set< AmpVecs* > sharedFriends );
+
+  /**
+   * This function will remove a shared data friend from the set
+   * which is necessary, e.g., if the friend goes out of scope.
+   */
+  void removeFriend( AmpVecs* dataFriend );
   
   bool m_usesSharedData;
-
+  AmpVecs* m_sharedDataHost;
+  
 private:
   
   int m_lastWeightSign;


### PR DESCRIPTION
This cleans up a few problems related to accessing freed memory in particular at the time objects are destroyed.  It may fix issues related to unexplained crashes at the end of jobs when working with fits that reuse data sets (e.g. same MC for multiple polarization configurations in GlueX applications) and/or fits that have gaussian bounded constraints.  This also fixes a GPU memory leak and removes an unnecessary data member.