### PR TITLE
N_gen set to sum weights

### DIFF
--- a/AmpTools/IUAmpTools/NormIntInterface.cc
+++ b/AmpTools/IUAmpTools/NormIntInterface.cc
@@ -137,7 +137,7 @@ NormIntInterface::~NormIntInterface(){
 istream&
 NormIntInterface::loadNormIntCache( istream& input )
 {
-  input >> m_nGenEvents >> m_sumAccWeights;
+  input >> m_sumGenWeights >> m_sumAccWeights;
   
   int numTerms;
   input >> numTerms;
@@ -191,7 +191,7 @@ NormIntInterface::operator+=( const NormIntInterface& nii )
   double nGenEvts = nii.numGenEvents();
   
   double totalAccEvts = nAccEvts + m_sumAccWeights;
-  double totalGenEvts = nGenEvts + m_nGenEvents;
+  double totalGenEvts = nGenEvts + m_sumGenWeights;
   
   string ampName, conjAmpName;
   
@@ -212,8 +212,8 @@ NormIntInterface::operator+=( const NormIntInterface& nii )
       m_ampIntCache[2*i*n+j+1] /= totalAccEvts;
 
       
-      m_ampIntCache[2*i*n+j]   *= m_nGenEvents;
-      m_ampIntCache[2*i*n+j+1] *= m_nGenEvents;
+      m_ampIntCache[2*i*n+j]   *= m_sumGenWeights;
+      m_ampIntCache[2*i*n+j+1] *= m_sumGenWeights;
       
       complex< double > ni = nii.normInt( m_termNames[i], m_termNames[j]  );
       
@@ -228,7 +228,7 @@ NormIntInterface::operator+=( const NormIntInterface& nii )
   
   
   m_sumAccWeights = totalAccEvts;
-  m_nGenEvents = totalGenEvts;
+  m_sumGenWeights = totalGenEvts;
   
   m_emptyNormIntCache = false;
   m_emptyAmpIntCache = false;
@@ -280,7 +280,7 @@ NormIntInterface::normInt( string amp, string conjAmp, bool forceUseCache ) cons
     report( DEBUG, kModule ) << "Request for normInt ( " << amp << ", " << conjAmp
     << " ) asking IntensityManager to calculate integrals." << endl;
     
-    m_pIntenManager->calcIntegrals( m_accMCVecs, m_nGenEvents );
+    m_pIntenManager->calcIntegrals( m_accMCVecs, m_sumGenWeights );
     setNormIntMatrix( m_accMCVecs.m_pdIntegralMatrix );
   }
 #endif
@@ -373,7 +373,7 @@ NormIntInterface::forceCacheUpdate( bool normIntOnly ) const
     report( DEBUG, kModule ) << "Asking IntensityManager to update integrals "
                              << "using the accepted MC." << endl;
     
-    m_pIntenManager->calcIntegrals( m_accMCVecs, m_nGenEvents );
+    m_pIntenManager->calcIntegrals( m_accMCVecs, m_sumGenWeights );
     setNormIntMatrix( m_accMCVecs.m_pdIntegralMatrix );
     
     m_emptyNormIntCache = false;
@@ -402,7 +402,7 @@ NormIntInterface::forceCacheUpdate( bool normIntOnly ) const
     report( DEBUG, kModule ) << "Asking IntensityManager to calculate integrals "
     << "using the generated MC." << endl;
     
-    m_pIntenManager->calcIntegrals( m_genMCVecs, m_nGenEvents, m_chunkSize );
+    m_pIntenManager->calcIntegrals( m_genMCVecs, m_sumGenWeights, m_chunkSize );
     
     setAmpIntMatrix( m_genMCVecs.m_pdIntegralMatrix );
 
@@ -427,7 +427,7 @@ NormIntInterface::forceCacheUpdate( bool normIntOnly ) const
   }
   else {
     
-    m_pIntenManager->calcIntegrals( m_accMCVecs, m_nGenEvents );
+    m_pIntenManager->calcIntegrals( m_accMCVecs, m_sumGenWeights );
     setNormIntMatrix( m_accMCVecs.m_pdIntegralMatrix );
   }
   m_emptyNormIntCache = false;
@@ -451,7 +451,11 @@ NormIntInterface::exportNormIntCache( ostream& out ) const
   if( m_emptyNormIntCache || m_emptyAmpIntCache ) forceCacheUpdate();
 #endif
   
-  out << m_nGenEvents << "\t" << m_sumAccWeights << endl;
+  // the static cast produces an output file that is backwards compatible
+  // with older versions that used integer number of generated events
+  // rather than the sum of the weights -- this should not make any
+  // signficant difference in a result
+  out << static_cast<int>(m_sumGenWeights) << "\t" << m_sumAccWeights << endl;
   
   out << m_termNames.size() << endl;
   
@@ -596,7 +600,7 @@ NormIntInterface::loadMC() const {
     
     genVecs->second->shareDataWith( &m_genMCVecs, m_pIntenManager->needsUserVarsOnly() );
   }
-  m_nGenEvents = m_genMCVecs.m_iNTrueEvents;
+  m_sumGenWeights = m_genMCVecs.m_dSumWeights;
 }
 
 void

--- a/AmpTools/IUAmpTools/NormIntInterface.cc
+++ b/AmpTools/IUAmpTools/NormIntInterface.cc
@@ -455,7 +455,7 @@ NormIntInterface::exportNormIntCache( ostream& out ) const
   // with older versions that used integer number of generated events
   // rather than the sum of the weights -- this should not make any
   // signficant difference in a result
-  out << static_cast<int>(m_sumGenWeights) << "\t" << m_sumAccWeights << endl;
+  out << static_cast<long int>(m_sumGenWeights) << "\t" << m_sumAccWeights << endl;
   
   out << m_termNames.size() << endl;
   

--- a/AmpTools/IUAmpTools/NormIntInterface.h
+++ b/AmpTools/IUAmpTools/NormIntInterface.h
@@ -69,7 +69,7 @@ public:
   istream& loadNormIntCache( istream& in );
   void operator+=( const NormIntInterface& nii );
   
-  size_t numGenEvents() const { return m_nGenEvents; }
+  double numGenEvents() const { return m_sumGenWeights; }
   double numAccEvents() const { return m_sumAccWeights; }
   
   // this integral folds in detector acceptance
@@ -103,7 +103,7 @@ public:
   const double* ampIntMatrix() const  { return m_ampIntCache;  }
   const double* normIntMatrix() const { return m_normIntCache; }
   
-  void setGenEvents( size_t events ) { m_nGenEvents = events; }
+  void setGenEvents( double sumWeights ) { m_sumGenWeights = sumWeights; }
   void setAccEvents( double sumWeights ) { m_sumAccWeights = sumWeights; }
   
 protected:
@@ -135,7 +135,7 @@ private:
   mutable bool m_emptyNormIntCache;
   mutable bool m_emptyAmpIntCache;
   
-  mutable size_t m_nGenEvents;
+  mutable double m_sumGenWeights;
   mutable double m_sumAccWeights;
   
 #ifndef __ACLIC__

--- a/AmpTools/IUAmpToolsMPI/NormIntInterfaceMPI.cc
+++ b/AmpTools/IUAmpToolsMPI/NormIntInterfaceMPI.cc
@@ -95,35 +95,34 @@ NormIntInterfaceMPI::setupMPI()
   
   m_isLeader = ( m_rank == 0 );
   
-  long int totalGenEvents = 0;
+  double totalGenWeights = 0;
   double totalAccWeights = 0;
     
   if( m_isLeader ){
     
     for( int i = 1; i < m_numProc; ++i ){
       
-      size_t thisEvents;
       double thisWeights;
 
       // trigger sending of events from followers -- data is irrelevant
-      MPI_Send( &thisEvents, 1, MPI_LONG, i, MPITag::kAcknowledge,
+      MPI_Send( &thisWeights, 1, MPI_DOUBLE, i, MPITag::kAcknowledge,
                MPI_COMM_WORLD );
       
       // now receive actual data
-      MPI_Recv( &thisEvents, 1, MPI_LONG, i, MPITag::kIntSend,
+      MPI_Recv( &thisWeights, 1, MPI_DOUBLE, i, MPITag::kDoubleSend,
                MPI_COMM_WORLD, &status );
-      totalGenEvents += thisEvents;
+      totalGenWeights += thisWeights;
       
       MPI_Recv( &thisWeights, 1, MPI_DOUBLE, i, MPITag::kDoubleSend,
                MPI_COMM_WORLD, &status );
       totalAccWeights += thisWeights;
       
       // send acknowledgment 
-      MPI_Send( &thisEvents, 1, MPI_LONG, i, MPITag::kAcknowledge,
+      MPI_Send( &thisWeights, 1, MPI_DOUBLE, i, MPITag::kAcknowledge,
                MPI_COMM_WORLD );
     }
     
-    setGenEvents( totalGenEvents );
+    setGenEvents( totalGenWeights );
     setAccEvents( totalAccWeights );
   }
   else{
@@ -134,7 +133,6 @@ NormIntInterfaceMPI::setupMPI()
     // usage on the lead node
     loadMC();
 
-    long int thisEvents;
     double thisWeights;
 
     // if we are not the leader, send generated and accepted events
@@ -145,16 +143,16 @@ NormIntInterfaceMPI::setupMPI()
     // to signal that it is ready to accept numbers of events
 
     // data is irrelevant for this receive
-    MPI_Recv( &thisEvents, 1, MPI_LONG, 0, MPITag::kAcknowledge, MPI_COMM_WORLD,
+    MPI_Recv( &thisWeights, 1, MPI_DOUBLE, 0, MPITag::kAcknowledge, MPI_COMM_WORLD,
               &status );
 
-    thisEvents = numGenEvents();
-    MPI_Send( &thisEvents, 1, MPI_LONG, 0, MPITag::kIntSend, MPI_COMM_WORLD );
+    thisWeights = numGenEvents();
+    MPI_Send( &thisWeights, 1, MPI_DOUBLE, 0, MPITag::kDoubleSend, MPI_COMM_WORLD );
     
     thisWeights = numAccEvents();
     MPI_Send( &thisWeights, 1, MPI_DOUBLE, 0, MPITag::kDoubleSend, MPI_COMM_WORLD );
     
-    MPI_Recv( &thisEvents, 1, MPI_LONG, 0, MPITag::kAcknowledge, MPI_COMM_WORLD,
+    MPI_Recv( &thisWeights, 1, MPI_DOUBLE, 0, MPITag::kAcknowledge, MPI_COMM_WORLD,
              &status );
   }
 }
@@ -185,8 +183,8 @@ NormIntInterfaceMPI::sumIntegrals( IntType type ) const
 
   // now broadcast the total number of events from the leader to the
   // followers so that they may renormalize the sum properly
-  long int totalEvents = numGenEvents();
-  MPI_Bcast( &totalEvents, 1, MPI_LONG, 0, MPI_COMM_WORLD );
+  double totalEvents = numGenEvents();
+  MPI_Bcast( &totalEvents, 1, MPI_DOUBLE, 0, MPI_COMM_WORLD );
   
   // and renormalize the sum
   for( int i = 0; i < cacheSize(); ++i ) result[i] /= totalEvents;


### PR DESCRIPTION
This modifies the Normalization Integral Interface to set the number of generated events equal to the sum of the weights in the generated MC sample.  This introduces consistency between how the accepted and generated MC samples are treated.